### PR TITLE
Support automatic discover when integration starts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 **/__pycache__/
+
+poetry.lock

--- a/README.md
+++ b/README.md
@@ -15,11 +15,14 @@ integration in Home Assistant.
 
 This integration supports the following additional features over the existing integration:
 
-* Configurable through the UI.
-* Allows to modify the balance mode, bypass mode, temperature profile and ventilation mode.
-* Changes to fan speed won't be reverted after 2 hours.
-* Support to clear alarms.
-* Ignores invalid sensor values at the beginning of a session. (Workaround for bridge firmware bug)
+* Configurable through the UI
+* Allows to modify the balance mode, bypass mode, temperature profile and ventilation mode
+* Changes to fan speed won't be reverted after 2 hours
+* Support to clear alarms
+* Ignores invalid sensor values at the beginning of a session (Workaround for bridge firmware bug)
+* Throttles high frequency sensor updates (airflow & fan duty) to once every 10 seconds
+
+**Note: Not all sensors are enabled by default. You can enable them on the integration page.**
 
 ## Installation
 

--- a/custom_components/comfoconnect/binary_sensor.py
+++ b/custom_components/comfoconnect/binary_sensor.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import DOMAIN, SIGNAL_COMFOCONNECT_UPDATE_RECEIVED, ComfoConnectBridge
+from .connection_sensor import comfo_connection_sensor_initialize
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,6 +73,12 @@ async def async_setup_entry(
         )
         for description in SENSOR_TYPES
     ]
+
+    connection_sensor = comfo_connection_sensor_initialize(
+        ccb=ccb, config_entry=config_entry
+    )
+
+    sensors.append(connection_sensor)
 
     async_add_entities(sensors, True)
 

--- a/custom_components/comfoconnect/connection_sensor.py
+++ b/custom_components/comfoconnect/connection_sensor.py
@@ -1,0 +1,75 @@
+"""Binary Sensor for the ComfoConnect integration."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.entity import DeviceInfo
+
+from . import DOMAIN, ComfoConnectBridge, set_conn_update
+
+
+_LOGGER = logging.getLogger(__name__)
+
+COMFO_CONNECTION_SENSOR: ComfoConnectionSensor = None
+
+
+def comfo_connection_sensor_initialize(
+        ccb: ComfoConnectBridge,
+        config_entry: ConfigEntry
+) -> ComfoConnectionSensor:
+    global COMFO_CONNECTION_SENSOR
+    COMFO_CONNECTION_SENSOR = ComfoConnectionSensor(
+        ccb=ccb, config_entry=config_entry
+    )
+    set_conn_update(comfo_connection_sensor_update)
+    return COMFO_CONNECTION_SENSOR
+
+
+def comfo_connection_sensor_update(value: bool) -> None:
+    if COMFO_CONNECTION_SENSOR is not None:
+        COMFO_CONNECTION_SENSOR.set_value(value)
+
+
+class ComfoConnectionSensor(BinarySensorEntity):
+    _attr_should_poll = False
+
+    def __init__(
+            self,
+            ccb: ComfoConnectBridge,
+            config_entry: ConfigEntry
+    ) -> None:
+        """Initialize the ComfoConnect sensor."""
+        self._ccb = ccb
+        self._attr_name = f"Connection"
+        self._attr_unique_id = f"{config_entry.unique_id}-" + "connection"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._ccb.uuid)},
+        )
+        self._attr_is_on = None
+        _LOGGER.error(
+            "Initializing Comfoconnect connection sensor",
+        )
+
+    def set_to_none(self):
+        self._attr_is_on = None
+
+    async def async_added_to_hass(self) -> None:
+        """Register for sensor updates."""
+        _LOGGER.error(
+            "Registering Comfoconnect connection sensor",
+        )
+        self.async_on_remove(self.set_to_none)
+
+    def set_value(self, value) -> None:
+        """Handle update callbacks."""
+        _LOGGER.error(
+            "Connection sensor update: %s",
+            value,
+        )
+
+        self._attr_is_on = value
+        self.schedule_update_ha_state()

--- a/custom_components/comfoconnect/fan.py
+++ b/custom_components/comfoconnect/fan.py
@@ -94,7 +94,9 @@ class ComfoConnectFan(FanEntity):
         _LOGGER.debug(
             "Handle update for fan speed (%d): %s", SENSOR_FAN_SPEED_MODE, value
         )
-        if value == 0:
+        if value is None:
+            self._attr_percentage = 0
+        elif value == 0:
             self._attr_percentage = 0
         else:
             self._attr_percentage = ordered_list_item_to_percentage(

--- a/custom_components/comfoconnect/sensor.py
+++ b/custom_components/comfoconnect/sensor.py
@@ -58,7 +58,7 @@ from . import DOMAIN, SIGNAL_COMFOCONNECT_UPDATE_RECEIVED, ComfoConnectBridge
 
 _LOGGER = logging.getLogger(__name__)
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=30)
 
 
 @dataclass
@@ -66,7 +66,7 @@ class ComfoconnectRequiredKeysMixin:
     """Mixin for required keys."""
 
     ccb_sensor: AioComfoConnectSensor
-    rounding: float
+
 
 @dataclass
 class ComfoconnectSensorEntityDescription(
@@ -74,7 +74,8 @@ class ComfoconnectSensorEntityDescription(
 ):
     """Describes ComfoConnect sensor entity."""
 
-    throttle: bool = False
+    throttle: bool = False,
+    minAllowedDifference: float = 0
 
 
 SENSOR_TYPES = (
@@ -85,7 +86,6 @@ SENSOR_TYPES = (
         name="Inside temperature",
         native_unit_of_measurement=TEMP_CELSIUS,
         ccb_sensor=SENSORS.get(SENSOR_TEMPERATURE_EXTRACT),
-        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_HUMIDITY_EXTRACT,
@@ -94,7 +94,6 @@ SENSOR_TYPES = (
         name="Inside humidity",
         native_unit_of_measurement=PERCENTAGE,
         ccb_sensor=SENSORS.get(SENSOR_HUMIDITY_EXTRACT),
-        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_RMOT,
@@ -105,7 +104,6 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_RMOT),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
-        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_TEMPERATURE_OUTDOOR,
@@ -114,7 +112,7 @@ SENSOR_TYPES = (
         name="Outside temperature",
         native_unit_of_measurement=TEMP_CELSIUS,
         ccb_sensor=SENSORS.get(SENSOR_TEMPERATURE_OUTDOOR),
-        rounding=0
+        minAllowedDifference=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_HUMIDITY_OUTDOOR,
@@ -123,7 +121,6 @@ SENSOR_TYPES = (
         name="Outside humidity",
         native_unit_of_measurement=PERCENTAGE,
         ccb_sensor=SENSORS.get(SENSOR_HUMIDITY_OUTDOOR),
-        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_TEMPERATURE_SUPPLY,
@@ -132,7 +129,6 @@ SENSOR_TYPES = (
         name="Supply temperature",
         native_unit_of_measurement=TEMP_CELSIUS,
         ccb_sensor=SENSORS.get(SENSOR_TEMPERATURE_SUPPLY),
-        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_HUMIDITY_SUPPLY,
@@ -141,7 +137,6 @@ SENSOR_TYPES = (
         name="Supply humidity",
         native_unit_of_measurement=PERCENTAGE,
         ccb_sensor=SENSORS.get(SENSOR_HUMIDITY_SUPPLY),
-        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_FAN_SUPPLY_SPEED,
@@ -152,7 +147,7 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_FAN_SUPPLY_SPEED),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
-        rounding=10
+        minAllowedDifference=10,
         throttle=True,
     ),
     ComfoconnectSensorEntityDescription(
@@ -164,7 +159,6 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_FAN_SUPPLY_DUTY),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
-        rounding=0
         throttle=True,
     ),
     ComfoconnectSensorEntityDescription(
@@ -176,7 +170,7 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_FAN_EXHAUST_SPEED),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
-        rounding=10
+        minAllowedDifference=10,
         throttle=True,
     ),
     ComfoconnectSensorEntityDescription(
@@ -188,7 +182,6 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_FAN_EXHAUST_DUTY),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
-        rounding=0
         throttle=True,
     ),
     ComfoconnectSensorEntityDescription(
@@ -198,7 +191,6 @@ SENSOR_TYPES = (
         name="Exhaust temperature",
         native_unit_of_measurement=TEMP_CELSIUS,
         ccb_sensor=SENSORS.get(SENSOR_TEMPERATURE_EXHAUST),
-        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_HUMIDITY_EXHAUST,
@@ -207,7 +199,6 @@ SENSOR_TYPES = (
         name="Exhaust humidity",
         native_unit_of_measurement=PERCENTAGE,
         ccb_sensor=SENSORS.get(SENSOR_HUMIDITY_EXHAUST),
-        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_FAN_SUPPLY_FLOW,
@@ -218,7 +209,7 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_FAN_SUPPLY_FLOW),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
-        rounding=10
+        minAllowedDifference=10,
         throttle=True,
     ),
     ComfoconnectSensorEntityDescription(
@@ -230,7 +221,7 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_FAN_EXHAUST_FLOW),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
-        rounding=10
+        minAllowedDifference=10,
         throttle=True,
     ),
     ComfoconnectSensorEntityDescription(
@@ -240,7 +231,6 @@ SENSOR_TYPES = (
         native_unit_of_measurement=PERCENTAGE,
         icon="mdi:camera-iris",
         ccb_sensor=SENSORS.get(SENSOR_BYPASS_STATE),
-        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_DAYS_TO_REPLACE_FILTER,
@@ -249,7 +239,6 @@ SENSOR_TYPES = (
         icon="mdi:calendar",
         ccb_sensor=SENSORS.get(SENSOR_DAYS_TO_REPLACE_FILTER),
         entity_category=EntityCategory.DIAGNOSTIC,
-        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_POWER_USAGE,
@@ -260,7 +249,7 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_POWER_USAGE),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
-        rounding=0
+        minAllowedDifference=0,
         throttle=True,
     ),
     ComfoconnectSensorEntityDescription(
@@ -272,7 +261,6 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_POWER_USAGE_TOTAL),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
-        rounding=0
         throttle=True,
     ),
     ComfoconnectSensorEntityDescription(
@@ -284,7 +272,6 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_PREHEATER_POWER),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
-        rounding=0
         throttle=True,
     ),
     ComfoconnectSensorEntityDescription(
@@ -296,7 +283,6 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_PREHEATER_POWER_TOTAL),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
-        rounding=0
         throttle=True,
     ),
 )
@@ -337,7 +323,7 @@ class ComfoConnectSensor(SensorEntity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._ccb.uuid)},
         )
-        self._rounding = description.rounding
+        self._minAllowedDifference = description.minAllowedDifference
         self._last_rcv_timestamp = None
         self._attr_native_value = None
 
@@ -373,14 +359,19 @@ class ComfoConnectSensor(SensorEntity):
             value,
         )
 
+        if value is None:
+            self._attr_native_value = value
+            self.schedule_update_ha_state()
+            return
+
         old_value = self._attr_native_value
         should_update = False
 
         if old_value is None:
             should_update = True
         else:
-            low_limit = old_value - (old_value * self._rounding) / 100
-            high_limit = old_value + (old_value * self._rounding) / 100
+            low_limit = old_value - (old_value * self._minAllowedDifference) / 100
+            high_limit = old_value + (old_value * self._minAllowedDifference) / 100
             if value > high_limit:
                 should_update = True
             if value < low_limit:
@@ -390,7 +381,7 @@ class ComfoConnectSensor(SensorEntity):
             self._attr_native_value = value
             self.schedule_update_ha_state()
 
-        self._last_rcv_timestamp = time.time();
+        self._last_rcv_timestamp = time.time()
 
     def _is_change(self, value) -> bool:
         old_value = self._attr_native_value
@@ -398,12 +389,12 @@ class ComfoConnectSensor(SensorEntity):
             "Old value %s new %s perc $s",
             old_value,
             value,
-            self._rounding
+            self._minAllowedDifference
         )
         if old_value is None:
             return True
-        low_limit = old_value - (old_value * self._rounding) / 100
-        high_limit = old_value + (old_value * self._rounding) / 100
+        low_limit = old_value - (old_value * self._minAllowedDifference) / 100
+        high_limit = old_value + (old_value * self._minAllowedDifference) / 100
         if value > high_limit:
             return True
         if value < low_limit:

--- a/custom_components/comfoconnect/sensor.py
+++ b/custom_components/comfoconnect/sensor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
 from datetime import timedelta
 
@@ -30,6 +31,7 @@ from aiocomfoconnect.sensors import (
     SENSORS,
     Sensor as AioComfoConnectSensor,
 )
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -64,7 +66,7 @@ class ComfoconnectRequiredKeysMixin:
     """Mixin for required keys."""
 
     ccb_sensor: AioComfoConnectSensor
-
+    rounding: float
 
 @dataclass
 class ComfoconnectSensorEntityDescription(
@@ -83,6 +85,7 @@ SENSOR_TYPES = (
         name="Inside temperature",
         native_unit_of_measurement=TEMP_CELSIUS,
         ccb_sensor=SENSORS.get(SENSOR_TEMPERATURE_EXTRACT),
+        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_HUMIDITY_EXTRACT,
@@ -91,6 +94,7 @@ SENSOR_TYPES = (
         name="Inside humidity",
         native_unit_of_measurement=PERCENTAGE,
         ccb_sensor=SENSORS.get(SENSOR_HUMIDITY_EXTRACT),
+        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_RMOT,
@@ -101,6 +105,7 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_RMOT),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
+        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_TEMPERATURE_OUTDOOR,
@@ -109,6 +114,7 @@ SENSOR_TYPES = (
         name="Outside temperature",
         native_unit_of_measurement=TEMP_CELSIUS,
         ccb_sensor=SENSORS.get(SENSOR_TEMPERATURE_OUTDOOR),
+        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_HUMIDITY_OUTDOOR,
@@ -117,6 +123,7 @@ SENSOR_TYPES = (
         name="Outside humidity",
         native_unit_of_measurement=PERCENTAGE,
         ccb_sensor=SENSORS.get(SENSOR_HUMIDITY_OUTDOOR),
+        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_TEMPERATURE_SUPPLY,
@@ -125,6 +132,7 @@ SENSOR_TYPES = (
         name="Supply temperature",
         native_unit_of_measurement=TEMP_CELSIUS,
         ccb_sensor=SENSORS.get(SENSOR_TEMPERATURE_SUPPLY),
+        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_HUMIDITY_SUPPLY,
@@ -133,6 +141,7 @@ SENSOR_TYPES = (
         name="Supply humidity",
         native_unit_of_measurement=PERCENTAGE,
         ccb_sensor=SENSORS.get(SENSOR_HUMIDITY_SUPPLY),
+        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_FAN_SUPPLY_SPEED,
@@ -143,6 +152,7 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_FAN_SUPPLY_SPEED),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
+        rounding=10
         throttle=True,
     ),
     ComfoconnectSensorEntityDescription(
@@ -154,6 +164,7 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_FAN_SUPPLY_DUTY),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
+        rounding=0
         throttle=True,
     ),
     ComfoconnectSensorEntityDescription(
@@ -165,6 +176,7 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_FAN_EXHAUST_SPEED),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
+        rounding=10
         throttle=True,
     ),
     ComfoconnectSensorEntityDescription(
@@ -176,6 +188,7 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_FAN_EXHAUST_DUTY),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
+        rounding=0
         throttle=True,
     ),
     ComfoconnectSensorEntityDescription(
@@ -185,6 +198,7 @@ SENSOR_TYPES = (
         name="Exhaust temperature",
         native_unit_of_measurement=TEMP_CELSIUS,
         ccb_sensor=SENSORS.get(SENSOR_TEMPERATURE_EXHAUST),
+        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_HUMIDITY_EXHAUST,
@@ -193,6 +207,7 @@ SENSOR_TYPES = (
         name="Exhaust humidity",
         native_unit_of_measurement=PERCENTAGE,
         ccb_sensor=SENSORS.get(SENSOR_HUMIDITY_EXHAUST),
+        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_FAN_SUPPLY_FLOW,
@@ -203,6 +218,7 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_FAN_SUPPLY_FLOW),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
+        rounding=10
         throttle=True,
     ),
     ComfoconnectSensorEntityDescription(
@@ -214,6 +230,7 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_FAN_EXHAUST_FLOW),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
+        rounding=10
         throttle=True,
     ),
     ComfoconnectSensorEntityDescription(
@@ -223,6 +240,7 @@ SENSOR_TYPES = (
         native_unit_of_measurement=PERCENTAGE,
         icon="mdi:camera-iris",
         ccb_sensor=SENSORS.get(SENSOR_BYPASS_STATE),
+        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_DAYS_TO_REPLACE_FILTER,
@@ -231,6 +249,7 @@ SENSOR_TYPES = (
         icon="mdi:calendar",
         ccb_sensor=SENSORS.get(SENSOR_DAYS_TO_REPLACE_FILTER),
         entity_category=EntityCategory.DIAGNOSTIC,
+        rounding=0
     ),
     ComfoconnectSensorEntityDescription(
         key=SENSOR_POWER_USAGE,
@@ -241,6 +260,7 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_POWER_USAGE),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
+        rounding=0
         throttle=True,
     ),
     ComfoconnectSensorEntityDescription(
@@ -252,6 +272,7 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_POWER_USAGE_TOTAL),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
+        rounding=0
         throttle=True,
     ),
     ComfoconnectSensorEntityDescription(
@@ -263,6 +284,7 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_PREHEATER_POWER),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
+        rounding=0
         throttle=True,
     ),
     ComfoconnectSensorEntityDescription(
@@ -274,6 +296,7 @@ SENSOR_TYPES = (
         ccb_sensor=SENSORS.get(SENSOR_PREHEATER_POWER_TOTAL),
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
+        rounding=0
         throttle=True,
     ),
 )
@@ -314,6 +337,9 @@ class ComfoConnectSensor(SensorEntity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._ccb.uuid)},
         )
+        self._rounding = description.rounding
+        self._last_rcv_timestamp = None
+        self._attr_native_value = None
 
     async def async_added_to_hass(self) -> None:
         """Register for sensor updates."""
@@ -347,5 +373,39 @@ class ComfoConnectSensor(SensorEntity):
             value,
         )
 
-        self._attr_native_value = value
-        self.schedule_update_ha_state()
+        old_value = self._attr_native_value
+        should_update = False
+
+        if old_value is None:
+            should_update = True
+        else:
+            low_limit = old_value - (old_value * self._rounding) / 100
+            high_limit = old_value + (old_value * self._rounding) / 100
+            if value > high_limit:
+                should_update = True
+            if value < low_limit:
+                should_update = True
+
+        if should_update:
+            self._attr_native_value = value
+            self.schedule_update_ha_state()
+
+        self._last_rcv_timestamp = time.time();
+
+    def _is_change(self, value) -> bool:
+        old_value = self._attr_native_value
+        _LOGGER.warning(
+            "Old value %s new %s perc $s",
+            old_value,
+            value,
+            self._rounding
+        )
+        if old_value is None:
+            return True
+        low_limit = old_value - (old_value * self._rounding) / 100
+        high_limit = old_value + (old_value * self._rounding) / 100
+        if value > high_limit:
+            return True
+        if value < low_limit:
+            return True
+        return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "home-assistant-comfoconnect"
+version = "0.1.0"
+description = ""
+authors = ["Michaël Arnauts <michael.arnauts@gmail.com>"]
+readme = "README.md"
+packages = [{include = "home_assistant_comfoconnect"}]
+
+[tool.poetry.dependencies]
+python = "^3.9"
+aiocomfoconnect = "^0.1.5"
+
+[tool.poetry.group.dev.dependencies]
+homeassistant = "^2022.12.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
If host: auto (as a string instead of IP) it will try to discover bridge and use its ip instead of configuring it in HA.
I know this is dirty solution :)