### PR TITLE
ComfoCool mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Home Assistant Zehnder ComfoAirQ integration
+# Home Assistant Zehnder ComfoAirQ / ComfoCoolQ integration
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
 
@@ -11,6 +11,7 @@ integration in Home Assistant.
 
 * Control ventilation speed
 * Control ventilation mode (auto / manual)
+* Control ComfoCool mode (auto / off)
 * Show various sensors
 
 This integration supports the following additional features over the existing integration:

--- a/custom_components/comfoconnect/select.py
+++ b/custom_components/comfoconnect/select.py
@@ -128,7 +128,9 @@ SELECT_TYPES = (
         name="ComfoCool Mode",
         entity_category=EntityCategory.CONFIG,
         get_value_fn=lambda ccb: cast(Coroutine, ccb.get_comfocool_mode()),
-        set_value_fn=lambda ccb, option: cast(Coroutine, ccb.set_comfocool_mode(option)),
+        set_value_fn=lambda ccb, option: cast(
+            Coroutine, ccb.set_comfocool_mode(option)
+        ),
         options=[
             ComfoCoolMode.AUTO,
             ComfoCoolMode.OFF,

--- a/custom_components/comfoconnect/select.py
+++ b/custom_components/comfoconnect/select.py
@@ -124,7 +124,7 @@ SELECT_TYPES = (
     ),
     ComfoconnectSelectEntityDescription(
         key="comfocool",
-        name="Comfocool Mode",
+        name="ComfoCool Mode",
         entity_category=EntityCategory.CONFIG,
         get_value_fn=lambda ccb: cast(Coroutine, ccb.get_comfocool_mode()),
         set_value_fn=lambda ccb, option: cast(Coroutine, ccb.set_comfocool_mode(option)),

--- a/custom_components/comfoconnect/select.py
+++ b/custom_components/comfoconnect/select.py
@@ -11,6 +11,7 @@ from aiocomfoconnect.const import (
     VentilationMode,
     VentilationSetting,
     VentilationTemperatureProfile,
+    ComfoCoolMode,
 )
 from aiocomfoconnect.sensors import (
     SENSOR_BYPASS_ACTIVATION_STATE,
@@ -120,6 +121,18 @@ SELECT_TYPES = (
             1: VentilationTemperatureProfile.COOL,
             2: VentilationTemperatureProfile.WARM,
         }.get(value),
+    ),
+    ComfoconnectSelectEntityDescription(
+        key="comfocool",
+        name="Comfocool Mode",
+        entity_category=EntityCategory.CONFIG,
+        get_value_fn=lambda ccb: cast(Coroutine, ccb.get_comfocool_mode()),
+        set_value_fn=lambda ccb, option: cast(Coroutine, ccb.set_comfocool_mode(option)),
+        options=[
+            ComfoCoolMode.AUTO,
+            ComfoCoolMode.OFF,
+        ],
+        # translation_key="comfocool",
     ),
 )
 

--- a/custom_components/comfoconnect/strings.json
+++ b/custom_components/comfoconnect/strings.json
@@ -22,6 +22,12 @@
           "normal": "Normal",
           "cool": "Cool"
         }
+      },
+      "comfocool": {
+        "state": {
+          "auto": "Auto",
+          "off": "Off"
+        }
       }
     }
   },

--- a/custom_components/comfoconnect/translations/en.json
+++ b/custom_components/comfoconnect/translations/en.json
@@ -57,6 +57,12 @@
                     "normal": "Normal",
                     "warm": "Warm"
                 }
+            },
+            "comfocool": {
+                "state": {
+                    "auto": "Auto",
+                    "off": "Off"
+                }
             }
         }
     }


### PR DESCRIPTION
Allow to choose ComfoCool Mode in Home Assistant. Reference to https://github.com/michaelarnauts/aiocomfoconnect/pull/27

I have check and it is working properly from command line:
```
python3 -m aiocomfoconnect set-comfocool off
```
![IMG_0891](https://github.com/michaelarnauts/home-assistant-comfoconnect/assets/329831/a6cda858-8dbc-4023-96af-ddb80c0dff78)
![IMG_0893](https://github.com/michaelarnauts/home-assistant-comfoconnect/assets/329831/2457c655-2282-4c92-9b63-53e2d1c2b708)
```
python3 -m aiocomfoconnect set-comfocool auto
```
![IMG_0892](https://github.com/michaelarnauts/home-assistant-comfoconnect/assets/329831/233b5946-cbd6-4471-aeef-6a08aca3472e)