### PR TITLE
Replace async_write_ha_stat with schedule_update_ha_state

### DIFF
--- a/custom_components/comfoconnect/select.py
+++ b/custom_components/comfoconnect/select.py
@@ -192,7 +192,7 @@ class ComfoConnectSelect(SelectEntity):
         )
 
         self._attr_current_option = self.entity_description.sensor_value_fn(value)
-        self.async_write_ha_state()
+        self.schedule_update_ha_state()
 
     async def async_update(self) -> None:
         """Update the state."""
@@ -204,4 +204,4 @@ class ComfoConnectSelect(SelectEntity):
         """Set the selected option."""
         await self.entity_description.set_value_fn(self._ccb, option)
         self._attr_current_option = option
-        self.async_write_ha_state()
+        self.schedule_update_ha_state()


### PR DESCRIPTION
I get a lot of 
```
Exception in _handle_update when dispatching 'comfoconnect_update_00000000000f10128001144fd71e07f5_66': (0,) Traceback (most recent call last): File "/config/custom_components/comfoconnect/select.py", line 217, in _handle_update self.async_write_ha_state() File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1008, in async_write_ha_state self.hass.verify_event_loop_thread("async_write_ha_state") File "/usr/src/homeassistant/homeassistant/core.py", line 440, in verify_event_loop_thread frame.report( File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 162, in report _report_integration(what, integration_frame, level, error_if_integration) File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 203, in _report_integration raise RuntimeError( RuntimeError: Detected that custom integration 'comfoconnect' calls async_write_ha_state from a thread at custom_components/comfoconnect/select.py, line 217: self.async_write_ha_state(). Please report it to the author of the 'comfoconnect' custom integration.
Exception in _handle_update when dispatching 'comfoconnect_update_00000000000f10128001144fd71e07f5_67': (0,) Traceback (most recent call last): File "/config/custom_components/comfoconnect/select.py", line 217, in _handle_update self.async_write_ha_state() File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1008, in async_write_ha_state self.hass.verify_event_loop_thread("async_write_ha_state") File "/usr/src/homeassistant/homeassistant/core.py", line 440, in verify_event_loop_thread frame.report( File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 162, in report _report_integration(what, integration_frame, level, error_if_integration) File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 203, in _report_integration raise RuntimeError( RuntimeError: Detected that custom integration 'comfoconnect' calls async_write_ha_state from a thread at custom_components/comfoconnect/select.py, line 217: self.async_write_ha_state(). Please report it to the author of the 'comfoconnect' custom integration.
Exception in _handle_update when dispatching 'comfoconnect_update_00000000000f10128001144fd71e07f5_56': (-1,) Traceback (most recent call last): File "/config/custom_components/comfoconnect/select.py", line 217, in _handle_update self.async_write_ha_state() File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1008, in async_write_ha_state self.hass.verify_event_loop_thread("async_write_ha_state") File "/usr/src/homeassistant/homeassistant/core.py", line 440, in verify_event_loop_thread frame.report( File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 162, in report _report_integration(what, integration_frame, level, error_if_integration) File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 203, in _report_integration raise RuntimeError( RuntimeError: Detected that custom integration 'comfoconnect' calls async_write_ha_state from a thread at custom_components/comfoconnect/select.py, line 217: self.async_write_ha_state(). Please report it to the author of the 'comfoconnect' custom integration.
Exception in _handle_update when dispatching 'comfoconnect_update_00000000000f10128001144fd71e07f5_56': (0,) Traceback (most recent call last): File "/config/custom_components/comfoconnect/select.py", line 217, in _handle_update self.async_write_ha_state() File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1008, in async_write_ha_state self.hass.verify_event_loop_thread("async_write_ha_state") File "/usr/src/homeassistant/homeassistant/core.py", line 440, in verify_event_loop_thread frame.report( File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 162, in report _report_integration(what, integration_frame, level, error_if_integration) File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 203, in _report_integration raise RuntimeError( RuntimeError: Detected that custom integration 'comfoconnect' calls async_write_ha_state from a thread at custom_components/comfoconnect/select.py, line 217: self.async_write_ha_state(). Please report it to the author of the 'comfoconnect' custom integration.
Exception in _handle_update when dispatching 'comfoconnect_update_00000000000f10128001144fd71e07f5_784': (1,) Traceback (most recent call last): File "/config/custom_components/comfoconnect/select.py", line 217, in _handle_update self.async_write_ha_state() File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1008, in async_write_ha_state self.hass.verify_event_loop_thread("async_write_ha_state") File "/usr/src/homeassistant/homeassistant/core.py", line 440, in verify_event_loop_thread frame.report( File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 162, in report _report_integration(what, integration_frame, level, error_if_integration) File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 203, in _report_integration raise RuntimeError( RuntimeError: Detected that custom integration 'comfoconnect' calls async_write_ha_state from a thread at custom_components/comfoconnect/select.py, line 217: self.async_write_ha_state(). Please report it to the author of the 'comfoconnect' custom integration.
```
Based on that thread https://github.com/michaelarnauts/home-assistant-comfoconnect/issues/50 with source from https://community.home-assistant.io/t/how-to-fix-custom-integration-brematic-calls-async-write-ha-state/722238/2

This is actually fix mentioned by @mrvanes