### PR TITLE
Bump aiocomfoconnect to 0.1.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{include = "custom_components/comfoconnect"}]
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.13"
-aiocomfoconnect = "^0.1.11"
+aiocomfoconnect = "^0.1.12"
 
 [tool.poetry.group.dev.dependencies]
 homeassistant = "^2024.06.0"


### PR DESCRIPTION
See https://github.com/michaelarnauts/aiocomfoconnect/releases/tag/v0.1.12

## What's Changed
* Initial Docker support by @szibis in https://github.com/michaelarnauts/aiocomfoconnect/pull/34
* Update analog input sensor to return 0-10V float values by @k7d in https://github.com/michaelarnauts/aiocomfoconnect/pull/35
* Update dependencies to support Python 3.12 by @michaelarnauts in https://github.com/michaelarnauts/aiocomfoconnect/pull/36
* Fix unholding sensors that don't have a value by @michaelarnauts in https://github.com/michaelarnauts/aiocomfoconnect/pull/37

## New Contributors
* @k7d made their first contribution in https://github.com/michaelarnauts/aiocomfoconnect/pull/35

**Full Changelog**: https://github.com/michaelarnauts/aiocomfoconnect/compare/v0.1.11...v0.1.12