### PR TITLE
adds Boost Mode control

### DIFF
--- a/custom_components/comfoconnect/select.py
+++ b/custom_components/comfoconnect/select.py
@@ -144,9 +144,7 @@ SELECT_TYPES = (
         icon="mdi:fan-plus",
         get_value_fn=lambda ccb: cast(Coroutine, ccb.get_boost()),
         set_value_fn=lambda ccb, option: cast(Coroutine, ccb.set_boost(True, int(option.split()[0]) * 60)),
-        options=[
-            "10 Minutes", "20 Minutes", "30 Minutes", "40 Minutes", "50 Minutes", "60 Minutes"
-        ],
+        options=["10 Minutes", "20 Minutes", "30 Minutes", "40 Minutes", "50 Minutes", "60 Minutes"],
     ),
 )
 

--- a/custom_components/comfoconnect/select.py
+++ b/custom_components/comfoconnect/select.py
@@ -138,6 +138,16 @@ SELECT_TYPES = (
             1: ComfoCoolMode.AUTO,
         }.get(value),
     ),
+    ComfoconnectSelectEntityDescription(
+        key="boost_timeout",
+        name="Boost Mode",
+        icon="mdi:fan-plus",
+        get_value_fn=lambda ccb: cast(Coroutine, ccb.get_boost()),
+        set_value_fn=lambda ccb, option: cast(Coroutine, ccb.set_boost(True, int(option) * 60)),
+        options=[
+            "10", "20", "30", "40", "50", "60"
+        ],
+    ),
 )
 
 

--- a/custom_components/comfoconnect/select.py
+++ b/custom_components/comfoconnect/select.py
@@ -143,9 +143,9 @@ SELECT_TYPES = (
         name="Boost Mode",
         icon="mdi:fan-plus",
         get_value_fn=lambda ccb: cast(Coroutine, ccb.get_boost()),
-        set_value_fn=lambda ccb, option: cast(Coroutine, ccb.set_boost(True, int(option) * 60)),
+        set_value_fn=lambda ccb, option: cast(Coroutine, ccb.set_boost(True, int(option.split()[0]) * 60)),
         options=[
-            "10", "20", "30", "40", "50", "60"
+            "10 Minutes", "20 Minutes", "30 Minutes", "40 Minutes", "50 Minutes", "60 Minutes"
         ],
     ),
 )


### PR DESCRIPTION
Adds an additional control for Boost Mode to the Zehnder ventilation unit device.  User selectable timeouts between 10 and 60 minutes in 10-minute increments