### PR TITLE
fan: fetch initial preset_mode from bridge on startup

### DIFF
--- a/custom_components/comfoconnect/fan.py
+++ b/custom_components/comfoconnect/fan.py
@@ -90,6 +90,7 @@ class ComfoConnectFan(FanEntity):
             )
         )
         await self._ccb.register_sensor(SENSORS.get(SENSOR_OPERATING_MODE))
+        self._attr_preset_mode = await self._ccb.get_mode()
 
     def _handle_speed_update(self, value: int) -> None:
         """Handle update callbacks."""


### PR DESCRIPTION
The fan entity and the ventilation mode select both register for SENSOR_OPERATING_MODE. The bridge only pushes the current value on first registration, so whichever entity registers second never receives the initial value and preset_mode stays null until the mode changes.

Fetching the mode explicitly in async_added_to_hass ensures preset_mode is populated immediately on startup, regardless of registration order. This also prevents the resulting WebSocket error where the tile card reflects the null state and HA rejects it as an invalid preset mode.

Will improve and eventually fix https://github.com/michaelarnauts/home-assistant-comfoconnect/issues/106 