### PR TITLE
refactor: replace schedule_update_ha_state() with async_write_ha_state()

### DIFF
--- a/custom_components/comfoconnect/binary_sensor.py
+++ b/custom_components/comfoconnect/binary_sensor.py
@@ -135,4 +135,4 @@ class ComfoConnectBinarySensor(BinarySensorEntity):
         )
 
         self._attr_is_on = True if value else False
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()

--- a/custom_components/comfoconnect/binary_sensor.py
+++ b/custom_components/comfoconnect/binary_sensor.py
@@ -20,7 +20,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -125,6 +125,7 @@ class ComfoConnectBinarySensor(BinarySensorEntity):
         )
         await self._ccb.register_sensor(self.entity_description.ccb_sensor)
 
+    @callback
     def _handle_update(self, value):
         """Handle update callbacks."""
         _LOGGER.debug(

--- a/custom_components/comfoconnect/fan.py
+++ b/custom_components/comfoconnect/fan.py
@@ -99,7 +99,7 @@ class ComfoConnectFan(FanEntity):
         else:
             self._attr_percentage = ordered_list_item_to_percentage(FAN_SPEEDS, FAN_SPEED_MAPPING[value])
 
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()
 
     def _handle_mode_update(self, value: int) -> None:
         """Handle update callbacks."""
@@ -109,7 +109,7 @@ class ComfoConnectFan(FanEntity):
             value,
         )
         self._attr_preset_mode = VentilationMode.AUTO if value == -1 else VentilationMode.MANUAL
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/comfoconnect/fan.py
+++ b/custom_components/comfoconnect/fan.py
@@ -14,7 +14,7 @@ from aiocomfoconnect.sensors import (
 )
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
@@ -94,6 +94,7 @@ class ComfoConnectFan(FanEntity):
         await self._ccb.register_sensor(SENSORS.get(SENSOR_OPERATING_MODE))
         self._attr_preset_mode = await self._ccb.get_mode()
 
+    @callback
     def _handle_speed_update(self, value: int) -> None:
         """Handle update callbacks."""
         _LOGGER.debug("Handle update for fan speed (%d): %s", SENSOR_FAN_SPEED_MODE, value)
@@ -104,6 +105,7 @@ class ComfoConnectFan(FanEntity):
 
         self.async_write_ha_state()
 
+    @callback
     def _handle_mode_update(self, value: int) -> None:
         """Handle update callbacks."""
         _LOGGER.debug(

--- a/custom_components/comfoconnect/fan.py
+++ b/custom_components/comfoconnect/fan.py
@@ -102,7 +102,7 @@ class ComfoConnectFan(FanEntity):
         else:
             self._attr_percentage = ordered_list_item_to_percentage(FAN_SPEEDS, FAN_SPEED_MAPPING[value])
 
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()
 
     def _handle_mode_update(self, value: int) -> None:
         """Handle update callbacks."""
@@ -112,7 +112,7 @@ class ComfoConnectFan(FanEntity):
             value,
         )
         self._attr_preset_mode = VentilationMode.AUTO if value == -1 else VentilationMode.MANUAL
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/comfoconnect/select.py
+++ b/custom_components/comfoconnect/select.py
@@ -212,7 +212,7 @@ class ComfoConnectSelect(SelectEntity):
         )
 
         self._attr_current_option = self.entity_description.sensor_value_fn(value)
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_update(self) -> None:
         """Update the state."""
@@ -222,4 +222,4 @@ class ComfoConnectSelect(SelectEntity):
         """Set the selected option."""
         await self.entity_description.set_value_fn(self._ccb, option)
         self._attr_current_option = option
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()

--- a/custom_components/comfoconnect/select.py
+++ b/custom_components/comfoconnect/select.py
@@ -26,7 +26,7 @@ from aiocomfoconnect.sensors import (
 )
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -202,6 +202,7 @@ class ComfoConnectSelect(SelectEntity):
         )
         await self._ccb.register_sensor(self.entity_description.sensor)
 
+    @callback
     def _handle_update(self, value):
         """Handle update callbacks."""
         _LOGGER.debug(

--- a/custom_components/comfoconnect/sensor.py
+++ b/custom_components/comfoconnect/sensor.py
@@ -449,4 +449,4 @@ class ComfoConnectSensor(SensorEntity):
             self._attr_native_value = self.entity_description.mapping(value)
         else:
             self._attr_native_value = value
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()

--- a/custom_components/comfoconnect/sensor.py
+++ b/custom_components/comfoconnect/sensor.py
@@ -60,7 +60,7 @@ from homeassistant.const import (
     UnitOfTime,
     UnitOfVolumeFlowRate,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -436,6 +436,7 @@ class ComfoConnectSensor(SensorEntity):
         )
         await self._ccb.register_sensor(self.entity_description.ccb_sensor)
 
+    @callback
     def _handle_update(self, value):
         """Handle update callbacks."""
         _LOGGER.debug(


### PR DESCRIPTION
All push-update callbacks were using schedule_update_ha_state() which internally uses call_soon_threadsafe — designed for scheduling work from outside the event loop. Since these callbacks are invoked by HA's dispatcher from within the event loop, the thread-safe hop is unnecessary.

Relates to #139