### PR TITLE
fix: add missing invalid_host error string to strings.json

### DIFF
--- a/custom_components/comfoconnect/strings.json
+++ b/custom_components/comfoconnect/strings.json
@@ -33,7 +33,8 @@
   },
   "config": {
     "error": {
-      "invalid_pin": "Invalid PIN"
+      "invalid_pin": "Invalid PIN",
+      "invalid_host": "Could not find a ComfoConnect bridge at this address"
     },
     "step": {
       "user": {


### PR DESCRIPTION
config_flow.py sets errors = {"base": "invalid_host"} when bridge discovery returns no results, but the key was not defined in strings.json causing the error to be silently swallowed with no user feedback.

Relates to #141