### PR TITLE
Update aiocomfoconnect to 0.2.0

### DIFF
--- a/custom_components/comfoconnect/manifest.json
+++ b/custom_components/comfoconnect/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/comfoconnect",
   "integration_type": "hub",
-  "requirements": ["aiocomfoconnect==0.1.15"],
+  "requirements": ["aiocomfoconnect==0.2.0"],
   "codeowners": ["@michaelarnauts"],
   "iot_class": "local_push",
   "loggers": ["aiocomfoconnect"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{include = "custom_components/comfoconnect"}]
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.13"
-aiocomfoconnect = "0.1.15"
+aiocomfoconnect = "0.2.0"
 
 [tool.poetry.group.dev.dependencies]
 homeassistant = "^2024.11.0b1"


### PR DESCRIPTION
Updates the library from 0.1.15 to [0.2.0](https://github.com/michaelarnauts/aiocomfoconnect/releases/tag/v0.2.0).

What this brings for this integration:

* Sensor values are held per sensor now instead of per connection ([#80](https://github.com/michaelarnauts/aiocomfoconnect/pull/80)). We register our sensors from `async_added_to_hass()`, so after `connect()` returned, and the old hold had usually expired by then on a cold boot. The invalid `0` that the bridge sends when we subscribe then reached the callback and polluted the statistics.
* Support for the new ComfoConnect Pro ([#74](https://github.com/michaelarnauts/aiocomfoconnect/pull/74)) and learning the node id of the ventilation unit from the bridge instead of assuming node 1 ([#79](https://github.com/michaelarnauts/aiocomfoconnect/pull/79)).
* `discover_bridges()` accepts the broadcast addresses to search ([#82](https://github.com/michaelarnauts/aiocomfoconnect/pull/82)), which is what #155 needs.
* Reworked connection handling ([#66](https://github.com/michaelarnauts/aiocomfoconnect/pull/66)).

No code changes are needed here: every name this integration imports from the library, and every method it calls on `ComfoConnect`, still exists with the same signature in 0.2.0.

One note while checking that: `fan.py` imports `ComfoConnectNotConnected`, which does not exist in 0.2.0. It does not exist in 0.1.15 either, so this is not caused by this update, see the separate report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)