### PR TITLE
Fix the fan platform failing to load

### DIFF
--- a/custom_components/comfoconnect/fan.py
+++ b/custom_components/comfoconnect/fan.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 from aiocomfoconnect.const import VentilationMode, VentilationSpeed
-from aiocomfoconnect.exceptions import ComfoConnectNotConnected, ComfoConnectRmiError
+from aiocomfoconnect.exceptions import AioComfoConnectNotConnected, ComfoConnectRmiError
 from aiocomfoconnect.sensors import (
     SENSOR_FAN_SPEED_MODE,
     SENSOR_OPERATING_MODE,
@@ -150,7 +150,7 @@ class ComfoConnectFan(FanEntity):
 
         try:
             await self._ccb.set_speed(speed)
-        except ComfoConnectNotConnected as err:
+        except AioComfoConnectNotConnected as err:
             raise HomeAssistantError(f"Not connected to ComfoConnect bridge: {err}") from err
         except ComfoConnectRmiError as err:
             raise HomeAssistantError(f"Failed to set fan speed: {err}") from err
@@ -163,7 +163,7 @@ class ComfoConnectFan(FanEntity):
         _LOGGER.debug("Changing preset mode to %s", preset_mode)
         try:
             await self._ccb.set_mode(preset_mode)
-        except ComfoConnectNotConnected as err:
+        except AioComfoConnectNotConnected as err:
             raise HomeAssistantError(f"Not connected to ComfoConnect bridge: {err}") from err
         except ComfoConnectRmiError as err:
             raise HomeAssistantError(f"Failed to set preset mode: {err}") from err


### PR DESCRIPTION
`fan.py` imports `ComfoConnectNotConnected` from the library, but no exception with that name has ever existed. It is called `AioComfoConnectNotConnected`, which is what `__init__.py` already imports. Since this is a module level import, it raises an `ImportError` and the whole fan platform fails to set up, which takes the setup of the config entry down with it.

```python
from aiocomfoconnect.exceptions import ComfoConnectNotConnected, ComfoConnectRmiError
```

I checked every released version of the library, 0.1.11 up to 0.2.0, and none of them has it, so this is not caused by the update to 0.2.0 in #156. It came in with e4d83a1 (`fan: handle bridge errors as HomeAssistantError`) on 2026-04-21.

Thanks @MattsBos for reporting this in #153 and for pinpointing the three lines, this is exactly the change you described.

While I was there I verified the rest: every `from aiocomfoconnect ... import ...` in `custom_components/comfoconnect/` resolves against 0.2.0, so there is no second occurrence of this hiding somewhere else.

Fixes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)
