### PR TITLE
Show the error when no bridge is found at the given address

### DIFF
--- a/custom_components/comfoconnect/translations/en.json
+++ b/custom_components/comfoconnect/translations/en.json
@@ -8,6 +8,7 @@
             "default": "Some sensors are not enabled by default. You can enable them in the entity registry after the integration configuration."
         },
         "error": {
+            "invalid_host": "Could not find a ComfoConnect bridge at this address",
             "invalid_pin": "Invalid PIN"
         },
         "step": {


### PR DESCRIPTION
#142 added the `invalid_host` error to `strings.json`, but not to `translations/en.json`. A custom integration reads its translations from the `translations/` directory at runtime, `strings.json` is the source that hassfest generates translations from for core integrations, so it has no effect here yet. Entering a host that does not answer therefore still shows the untranslated key instead of the message.

The config flow raises it in `async_step_manual()`:

```python
bridges = await aiocomfoconnect.discover_bridges(user_input[CONF_HOST])
if len(bridges) == 0:
    errors = {"base": "invalid_host"}
```

The text is copied from `strings.json` so both files agree.

Not in this PR: comparing the two files shows seven more keys whose text has drifted apart (`config.step.user.data.host`, `config.abort.no_devices_found`, `config.step.confirm.description`, `entity.select.setting.state.on` and `off`, `config.step.manual.data.host`, `config.abort.reauth_successful`). Worth syncing, but that is a bigger change than this fix.

Fixes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)