### PR TITLE
Discover bridges on every network that Home Assistant uses

### DIFF
--- a/custom_components/comfoconnect/__init__.py
+++ b/custom_components/comfoconnect/__init__.py
@@ -19,6 +19,7 @@ from aiocomfoconnect.properties import (
 )
 from aiocomfoconnect.sensors import Sensor
 from aiocomfoconnect.util import version_decode
+from homeassistant.components import network
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant, callback
@@ -84,7 +85,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.data[CONF_HOST],
         )
 
-        bridges = await discover_bridges()
+        broadcast_addresses = await network.async_get_ipv4_broadcast_addresses(hass)
+        bridges = await discover_bridges(broadcast_addresses=broadcast_addresses)
         discovered_bridge = next((b for b in bridges if b.uuid == entry.data[CONF_UUID]), None)
         if not discovered_bridge:
             _LOGGER.warning('Unable to discover bridge "%s". Retrying later.', entry.data[CONF_UUID])

--- a/custom_components/comfoconnect/config_flow.py
+++ b/custom_components/comfoconnect/config_flow.py
@@ -10,6 +10,7 @@ import voluptuous as vol
 from aiocomfoconnect import Bridge
 from aiocomfoconnect.exceptions import ComfoConnectNotAllowed
 from homeassistant import config_entries
+from homeassistant.components import network
 from homeassistant.const import CONF_HOST, CONF_PIN
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.typing import ConfigType
@@ -63,8 +64,9 @@ class ComfoConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 return await self._register()
 
-        # Find bridges on the network and filter out the ones we already have configured
-        bridges = await aiocomfoconnect.discover_bridges()
+        # Find bridges on the networks that Home Assistant is configured to use, and filter out the ones we already have configured
+        broadcast_addresses = await network.async_get_ipv4_broadcast_addresses(self.hass)
+        bridges = await aiocomfoconnect.discover_bridges(broadcast_addresses=broadcast_addresses)
         self.discovered_bridges = {bridge.uuid: bridge for bridge in bridges if bridge.uuid not in self._async_current_ids(False)}
 
         # Show the bridge selection form

--- a/custom_components/comfoconnect/manifest.json
+++ b/custom_components/comfoconnect/manifest.json
@@ -2,6 +2,7 @@
   "domain": "comfoconnect",
   "name": "Zehnder ComfoAir Q",
   "config_flow": true,
+  "dependencies": ["network"],
   "documentation": "https://www.home-assistant.io/integrations/comfoconnect",
   "integration_type": "hub",
   "requirements": ["aiocomfoconnect==0.2.0"],


### PR DESCRIPTION
Discovery sent its request to the limited broadcast address (`255.255.255.255`), which is not duplicated across interfaces: the operating system does a routing lookup and picks exactly one, like it would for a unicast packet.

```
$ ip route get 255.255.255.255
broadcast 255.255.255.255 dev eth0 src 192.168.1.59
```

A bridge behind any other interface was therefore never found, and the user had to fall back to adding it manually. See michaelarnauts/aiocomfoconnect#61 for the analysis.

aiocomfoconnect 0.2.0 accepts the networks to search (michaelarnauts/aiocomfoconnect#82), and Home Assistant knows which ones they are, so we pass them along:

```python
broadcast_addresses = await network.async_get_ipv4_broadcast_addresses(hass)
bridges = await discover_bridges(broadcast_addresses=broadcast_addresses)
```

`async_get_ipv4_broadcast_addresses()` returns the directed broadcast address of every adapter the user enabled under Settings > Network, plus `255.255.255.255`. A directed broadcast like `192.168.1.255` is routed over the interface that owns that subnet, so this needs no interface binding and no extra dependency, and it follows the adapter preferences that the user configured. This is the documented approach for integrations that do their own broadcast discovery: https://developers.home-assistant.io/docs/network_discovery/

Both discovery call sites are covered:

* `config_flow.async_step_user()`, which searches for bridges to set up.
* `async_setup_entry()`, which rediscovers the bridge when it stopped answering at its known address, for example after its IP changed. This one runs unattended at startup, so a bridge on another interface would leave the entry stuck in `ConfigEntryNotReady`.

`async_step_manual()` is unchanged, it passes a host and stays unicast.

`network` is added to the dependencies in `manifest.json`, since Home Assistant requires that for integrations using its API.

Fixes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)