### PR TITLE
Register through the public API of the library

### DIFF
--- a/custom_components/comfoconnect/config_flow.py
+++ b/custom_components/comfoconnect/config_flow.py
@@ -114,31 +114,23 @@ class ComfoConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # Generate our own UUID if non is provided
             self.local_uuid = random_uuid_hex()
 
-        # Connect to the bridge
-        await self.bridge._connect(self.local_uuid)
         try:
-            await self.bridge.cmd_start_session(True)
+            # This connects to the bridge, checks if we are registered already by starting a session,
+            # and registers us when we are not.
+            await self.bridge.register(
+                self.local_uuid,
+                "Home Assistant (%s)" % self.hass.config.location_name,
+                pin or DEFAULT_PIN,
+            )
 
         except ComfoConnectNotAllowed:
-            try:
-                # We probably are not registered yet, lets try to register.
-                await self.bridge.cmd_register_app(
-                    self.local_uuid,
-                    "Home Assistant (%s)" % self.hass.config.location_name,
-                    pin or DEFAULT_PIN,
-                )
-
-            except ComfoConnectNotAllowed:
-                # We have tried connecting, but we have an invalid PIN. Ask the user for a new PIN.
-                errors = {"base": "invalid_pin"} if pin is not None else {}
-                return await self.async_step_enter_pin({}, errors)
-
-            # Registration went fine, connect to the bridge again
-            await self.bridge.cmd_start_session(True)
+            # We are not registered yet and the bridge refused the PIN. Ask the user for a new PIN.
+            errors = {"base": "invalid_pin"} if pin is not None else {}
+            return await self.async_step_enter_pin({}, errors)
 
         finally:
             # Disconnect
-            await self.bridge._disconnect()
+            await self.bridge.disconnect()
 
         if self.context.get("source") == config_entries.SOURCE_REAUTH:
             self.hass.async_create_task(self.hass.config_entries.async_reload(self.context["entry_id"]))


### PR DESCRIPTION
**This fixes a regression from #156.** Adding a bridge is currently broken on master.

`_register()` called `Bridge._connect()` and `Bridge._disconnect()`, two private methods that were renamed to `_open_connection()` and `disconnect()` when the connection handling was reworked in michaelarnauts/aiocomfoconnect#66. Since we moved the pin to 0.2.0, both calls raise `AttributeError`, so the config flow fails for anyone adding the integration or going through re-authentication.

```
_connect           *** MISSING ***      (was aiocomfoconnect 0.1.15, bridge.py:96)
_disconnect        *** MISSING ***      (was aiocomfoconnect 0.1.15, bridge.py:128)
```

Rather than chase the new private names, this switches to `Bridge.register()`, which the library gained in 0.2.0 and which does exactly what was hand rolled here: open the connection, start a session to find out whether we are registered already, register when we are not, and raise `ComfoConnectNotAllowed` when the bridge refuses the PIN. So the `invalid_pin` handling keeps working the same way.

A side effect worth having: `register()` skips the session probe on a ComfoConnect Pro, which needs to register before it will accept a session. That is one piece of #53, though the Pro still needs `bridge_type` to be stored in the config entry and passed to `ComfoConnect` before it works end to end.

I checked the rest of the integration the same way: every attribute it uses on `Bridge`/`ComfoConnect` exists in 0.2.0, these two were the only casualties of the rename.

Note this is exactly the class of bug the current CI cannot see, since it only runs ruff and there are no tests, so nothing ever imports or exercises this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)