### PR TITLE
Rediscover the bridge when it can't be reached

### DIFF
--- a/custom_components/comfoconnect/__init__.py
+++ b/custom_components/comfoconnect/__init__.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 from aiocomfoconnect import ComfoConnect, discover_bridges
 from aiocomfoconnect.exceptions import (
     AioComfoConnectNotConnected,
+    AioComfoConnectNotReachable,
     AioComfoConnectTimeout,
     ComfoConnectError,
     ComfoConnectNotAllowed,
@@ -78,10 +79,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except ComfoConnectError as err:
         raise ConfigEntryError from err
 
-    except AioComfoConnectTimeout as err:
-        # We got a timeout, this can happen when the IP address of the bridge has changed.
+    except (AioComfoConnectTimeout, AioComfoConnectNotReachable) as err:
+        # We can't reach the bridge, this can happen when the IP address of the bridge has changed.
         _LOGGER.warning(
-            'Timeout connecting to bridge "%s", trying discovery again.',
+            'Could not connect to bridge "%s", trying discovery again.',
             entry.data[CONF_HOST],
         )
 
@@ -149,12 +150,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
             # TODO: Mark sensors as available
 
-        except (AioComfoConnectNotConnected, AioComfoConnectTimeout):
+        except (AioComfoConnectNotConnected, AioComfoConnectTimeout, AioComfoConnectNotReachable):
             # Reconnect when connection has been dropped
             try:
                 await bridge.connect(entry.data[CONF_LOCAL_UUID])
-            except AioComfoConnectTimeout:
-                _LOGGER.debug("Connection timed out. Retrying later...")
+            except (AioComfoConnectTimeout, AioComfoConnectNotReachable):
+                _LOGGER.debug("Could not connect to the bridge. Retrying later...")
 
                 # TODO: Mark all sensors as unavailable
 

--- a/custom_components/comfoconnect/manifest.json
+++ b/custom_components/comfoconnect/manifest.json
@@ -5,7 +5,7 @@
   "dependencies": ["network"],
   "documentation": "https://www.home-assistant.io/integrations/comfoconnect",
   "integration_type": "hub",
-  "requirements": ["aiocomfoconnect==0.2.0"],
+  "requirements": ["aiocomfoconnect==0.2.1"],
   "codeowners": ["@michaelarnauts"],
   "iot_class": "local_push",
   "loggers": ["aiocomfoconnect"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{include = "custom_components/comfoconnect"}]
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.13"
-aiocomfoconnect = "0.2.0"
+aiocomfoconnect = "0.2.1"
 
 [tool.poetry.group.dev.dependencies]
 homeassistant = "^2024.11.0b1"


### PR DESCRIPTION
Follow up on michaelarnauts/aiocomfoconnect#83, and bumps the library to [0.2.1](https://github.com/michaelarnauts/aiocomfoconnect/releases/tag/v0.2.1) which contains it.

When the bridge is gone from the network, `asyncio.open_connection()` raises an `OSError` rather than timing out:

```
OSError: [Errno 113] Connect call failed (192.168.178.142, 56747)
```

The library let that escape untranslated, and we only catch `ComfoConnectNotAllowed`, `ComfoConnectError` and `AioComfoConnectTimeout`. So setting up the entry failed with an unknown error, and the rediscovery in `async_setup_entry()` that exists exactly for a bridge that changed address never ran. See #100.

0.2.1 translates it to `AioComfoConnectNotReachable`, so this handles it in the three places where a timeout is already handled:

* `async_setup_entry()`, which then rediscovers the bridge and updates the host in the config entry.
* the keepalive, which reconnects.
* the reconnect inside the keepalive, which retries later.

The messages no longer say "timeout" since a refused or unreachable connection is not one.

The version bump and the handling are in the same commit on purpose: the exception does not exist in 0.2.0, so importing it while pinned to 0.2.0 would fail at import time and take the integration down, which is what happened in #153.

I verified every `from aiocomfoconnect ... import ...` in the component against the sdist that was published to PyPI as 0.2.1, rather than a local checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)