### PR TITLE
Detect the bridge type when re-authenticating

### DIFF
--- a/custom_components/comfoconnect/config_flow.py
+++ b/custom_components/comfoconnect/config_flow.py
@@ -41,7 +41,11 @@ class ComfoConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reauth(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle a flow reauth."""
-        self.bridge = Bridge(user_input[CONF_HOST], user_input[CONF_UUID])
+        # Discover the bridge so we know which type it is, since a ComfoConnect Pro needs to be
+        # registered differently than a LAN C. Fall back to the stored data when it doesn't answer.
+        bridges = await aiocomfoconnect.discover_bridges(user_input[CONF_HOST])
+        discovered_bridge = next((bridge for bridge in bridges if bridge.uuid == user_input[CONF_UUID]), None)
+        self.bridge = discovered_bridge or Bridge(user_input[CONF_HOST], user_input[CONF_UUID])
         self.local_uuid = user_input[CONF_LOCAL_UUID]
 
         return await self._register()


### PR DESCRIPTION
You were right that we do not need to store the bridge type anywhere. I checked what michaelarnauts/aiocomfoconnect#74 actually added, and the entire Pro specific surface is the registration order:

```python
if self.bridge_type != GATEWAY_TYPE_PRO:
    # LAN C: check whether we are already registered by starting a session.
```

That is the only place in the library that reads `bridge_type`. Sessions, RPDO, RMI and the keepalive are identical for both, so passing it to `ComfoConnect` at runtime would do nothing, and the config entry does not need to carry it.

Discovery fills it in automatically (`discovery.py`), and both setup paths use a discovered bridge, so they are already correct. The exception is the reauth step, which builds one by hand:

```python
self.bridge = Bridge(user_input[CONF_HOST], user_input[CONF_UUID])
```

That defaults to `bridge_type=0`, a LAN C. And reauth is the one moment where it matters: we get there through `ConfigEntryAuthFailed`, which means we are not registered anymore, which is exactly the case the Pro branch exists for. So a Pro owner recovering from a dropped registration would take the LAN C path and run into the connection timeout that `register()` documents.

This looks the bridge up through discovery like `async_step_manual()` already does, and falls back to the stored data when it does not answer, so nothing changes for a bridge that is reachable but silent on discovery.

Scope note: this is the last gap I can find for #53 in this repo. Whether a Pro works end to end once registered is still unconfirmed, that needs someone from that thread to try it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)