### PR TITLE
Run the tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,3 +44,6 @@ jobs:
 
       - name: Run checks
         run: make check
+
+      - name: Run tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,11 @@ check:
 	@poetry run ruff check
 	@poetry run ruff format --check
 
+test:
+	@poetry run pytest
+
 codefix:
 	@poetry run ruff check --fix
 	@poetry run ruff format
 
-.PHONY: check codefix
+.PHONY: check codefix test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,11 @@ aiocomfoconnect = "0.2.1"
 
 [tool.poetry.group.dev.dependencies]
 homeassistant = "^2024.11.0b1"
+pytest = "^8.3"
 ruff = "^0.5.2"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
 
 [build-system]
 requires = ["poetry-core"]
@@ -71,3 +75,7 @@ extend-select = [
     "T20",
     "W",
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests are allowed to use assert, and don't need to be a package.
+"tests/*" = ["S101", "INP001"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+"""Pytest configuration."""
+
+import sys
+from pathlib import Path
+
+# Make custom_components importable, since it isn't installed as a package.
+sys.path.insert(0, str(Path(__file__).parent.parent))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,79 @@
+"""
+Tests that the integration can be loaded, and that its manifest matches what it needs.
+
+These don't test any behaviour yet, they make sure the integration imports at all. Home Assistant
+imports every platform when it sets up the config entry, so a name that doesn't exist in the
+version of aiocomfoconnect we pin takes the whole integration down at runtime, and neither ruff
+nor the formatter can see that.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import re
+import tomllib
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+import pytest
+
+COMPONENT_PATH = Path(__file__).parent.parent / "custom_components" / "comfoconnect"
+MANIFEST_PATH = COMPONENT_PATH / "manifest.json"
+PYPROJECT_PATH = Path(__file__).parent.parent / "pyproject.toml"
+
+# Every module of the integration, so a new platform is covered without touching this file.
+MODULES = sorted(path.stem for path in COMPONENT_PATH.glob("*.py"))
+
+
+@pytest.fixture(name="manifest")
+def manifest_fixture() -> dict:
+    """Return the parsed manifest."""
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("module", MODULES)
+def test_module_can_be_imported(module: str) -> None:
+    """Test that every module of the integration can be imported."""
+    importlib.import_module(f"custom_components.comfoconnect.{module}")
+
+
+def test_all_platforms_are_covered() -> None:
+    """Test that the platforms the integration sets up are all present."""
+    integration = importlib.import_module("custom_components.comfoconnect")
+
+    for platform in integration.PLATFORMS:
+        assert platform.value in MODULES
+
+
+def test_manifest_has_what_home_assistant_needs(manifest: dict) -> None:
+    """Test that the manifest has the keys Home Assistant requires from a custom integration."""
+    for key in ("domain", "name", "documentation", "codeowners", "requirements", "version"):
+        assert manifest.get(key), f"{key} is missing from the manifest"
+
+    assert manifest["domain"] == "comfoconnect"
+
+
+def test_manifest_version_matches_pyproject(manifest: dict) -> None:
+    """Test that both places that carry our version agree, since a release has to bump both."""
+    pyproject = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+
+    assert manifest["version"] == pyproject["tool"]["poetry"]["version"]
+
+
+def test_requirements_match_the_installed_library(manifest: dict) -> None:
+    """
+    Test that we import the library version we pin.
+
+    The modules above are imported against whatever is installed, so this makes sure that is the
+    version users get, instead of the tests passing against something newer than the pin.
+    """
+    for requirement in manifest["requirements"]:
+        name, pinned = re.match(r"([\w-]+)==(.+)", requirement).groups()
+
+        try:
+            installed = version(name)
+        except PackageNotFoundError:
+            pytest.skip(f"{name} is not installed")
+
+        assert installed == pinned, f"{name} {installed} is installed, but the manifest pins {pinned}"


### PR DESCRIPTION
There are no tests in this repository, and CI only runs ruff. A linter can see that an imported name is used, but not whether it exists in the version of `aiocomfoconnect` that we pin, since that means resolving an installed third party module. That is why the broken `ComfoConnectNotConnected` import in #153 took the fan platform down for months with CI green the whole time, and why the `Bridge._connect()` call in #160 slipped through as well.

These tests don not cover behaviour yet, they cover the thing that actually broke:

* Every module of the integration is imported, which is what Home Assistant does when it sets up the config entry. New platforms are picked up automatically, the list is read from the directory.
* The platforms in `PLATFORMS` all exist as a module.
* The manifest has the keys Home Assistant needs.
* The manifest version matches the one in `pyproject.toml`, since a release has to bump both and it is easy to bump only one.
* The library version that gets imported is the one the manifest pins, so the tests can not pass against something newer than what users install.

Wiring:

* `pytest` as a dev dependency, `make test`, and a step in CI after `make check`.
* `tests/*` is exempted from `S101` and `INP001` in the ruff config, since tests use `assert` and are not a package.

Next step, when there is appetite for it, is `pytest-homeassistant-custom-component`, which gives a `hass` fixture and lets us test the config flow and the entities properly. That pins Home Assistant versions strictly, so it deserves its own change.

Note: I could not run these locally, this container has no working Home Assistant install, so CI is the first real run. If something needs adjusting I will fix it forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)