### PR TITLE
Mark the entities unavailable when the bridge is gone

### DIFF
--- a/custom_components/comfoconnect/__init__.py
+++ b/custom_components/comfoconnect/__init__.py
@@ -30,7 +30,7 @@ from homeassistant.exceptions import (
     ConfigEntryNotReady,
 )
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.dispatcher import dispatcher_send
+from homeassistant.helpers.dispatcher import async_dispatcher_send, dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType
 
@@ -47,6 +47,7 @@ PLATFORMS: list[Platform] = [
 _LOGGER = logging.getLogger(__name__)
 
 SIGNAL_COMFOCONNECT_UPDATE_RECEIVED = "comfoconnect_update_{}_{}"
+SIGNAL_COMFOCONNECT_AVAILABILITY = "comfoconnect_availability_{}"
 
 KEEP_ALIVE_INTERVAL = timedelta(seconds=30)
 
@@ -147,17 +148,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         try:
             # Use cmd_time_request as a keepalive since cmd_keepalive doesn't send back a reply we can wait for
             await bridge.cmd_time_request()
-
-            # TODO: Mark sensors as available
+            bridge.set_available(True)
 
         except (AioComfoConnectNotConnected, AioComfoConnectTimeout, AioComfoConnectNotReachable):
+            bridge.set_available(False)
+
             # Reconnect when connection has been dropped
             try:
                 await bridge.connect(entry.data[CONF_LOCAL_UUID])
+                bridge.set_available(True)
             except (AioComfoConnectTimeout, AioComfoConnectNotReachable):
                 _LOGGER.debug("Could not connect to the bridge. Retrying later...")
-
-                # TODO: Mark all sensors as unavailable
 
     entry.async_on_unload(async_track_time_interval(hass, send_keepalive, KEEP_ALIVE_INTERVAL))
 
@@ -194,6 +195,18 @@ class ComfoConnectBridge(ComfoConnect):
             self.alarm_callback,
         )
         self.hass = hass
+        self.is_available = True
+
+    @callback
+    def set_available(self, available: bool) -> None:
+        """Update the availability of the bridge, and tell the entities about it."""
+        if self.is_available == available:
+            return
+
+        self.is_available = available
+        _LOGGER.info("Bridge %s is %s", self.uuid, "available" if available else "unavailable")
+
+        async_dispatcher_send(self.hass, SIGNAL_COMFOCONNECT_AVAILABILITY.format(self.uuid), available)
 
     @callback
     def sensor_callback(self, sensor: Sensor, value):

--- a/custom_components/comfoconnect/binary_sensor.py
+++ b/custom_components/comfoconnect/binary_sensor.py
@@ -20,12 +20,17 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DOMAIN, SIGNAL_COMFOCONNECT_UPDATE_RECEIVED, ComfoConnectBridge
+from . import (
+    DOMAIN,
+    SIGNAL_COMFOCONNECT_AVAILABILITY,
+    SIGNAL_COMFOCONNECT_UPDATE_RECEIVED,
+    ComfoConnectBridge,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -105,12 +110,21 @@ class ComfoConnectBinarySensor(BinarySensorEntity):
         self.entity_description = description
         self._attr_name = f"{description.name}"
         self._attr_unique_id = f"{self._ccb.uuid}-{description.key}"
+        self._attr_available = ccb.is_available
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._ccb.uuid)},
         )
 
     async def async_added_to_hass(self) -> None:
-        """Register for sensor updates."""
+        """Register for sensor and availability updates."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                SIGNAL_COMFOCONNECT_AVAILABILITY.format(self._ccb.uuid),
+                self._handle_availability_update,
+            )
+        )
+
         _LOGGER.debug(
             "Registering for sensor %s (%d)",
             self.entity_description.name,
@@ -124,6 +138,12 @@ class ComfoConnectBinarySensor(BinarySensorEntity):
             )
         )
         await self._ccb.register_sensor(self.entity_description.ccb_sensor)
+
+    @callback
+    def _handle_availability_update(self, available: bool) -> None:
+        """Handle availability updates of the bridge."""
+        self._attr_available = available
+        self.async_write_ha_state()
 
     def _handle_update(self, value):
         """Handle update callbacks."""

--- a/custom_components/comfoconnect/button.py
+++ b/custom_components/comfoconnect/button.py
@@ -9,11 +9,12 @@ from typing import Any, Callable, cast
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DOMAIN, ComfoConnectBridge
+from . import DOMAIN, SIGNAL_COMFOCONNECT_AVAILABILITY, ComfoConnectBridge
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,9 +71,26 @@ class ComfoConnectButton(ButtonEntity):
         self.entity_description = description
         self._attr_name = f"{description.name}"
         self._attr_unique_id = f"{self._ccb.uuid}-{description.key}"
+        self._attr_available = ccb.is_available
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._ccb.uuid)},
         )
+
+    async def async_added_to_hass(self) -> None:
+        """Register for availability updates."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                SIGNAL_COMFOCONNECT_AVAILABILITY.format(self._ccb.uuid),
+                self._handle_availability_update,
+            )
+        )
+
+    @callback
+    def _handle_availability_update(self, available: bool) -> None:
+        """Handle availability updates of the bridge."""
+        self._attr_available = available
+        self.async_write_ha_state()
 
     async def async_press(self) -> None:
         """Press the button."""

--- a/custom_components/comfoconnect/fan.py
+++ b/custom_components/comfoconnect/fan.py
@@ -14,7 +14,7 @@ from aiocomfoconnect.sensors import (
 )
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
@@ -24,7 +24,12 @@ from homeassistant.util.percentage import (
     percentage_to_ordered_list_item,
 )
 
-from . import DOMAIN, SIGNAL_COMFOCONNECT_UPDATE_RECEIVED, ComfoConnectBridge
+from . import (
+    DOMAIN,
+    SIGNAL_COMFOCONNECT_AVAILABILITY,
+    SIGNAL_COMFOCONNECT_UPDATE_RECEIVED,
+    ComfoConnectBridge,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -67,12 +72,21 @@ class ComfoConnectFan(FanEntity):
         self._ccb = ccb
         self._attr_unique_id = self._ccb.uuid
         self._attr_preset_mode = None
+        self._attr_available = ccb.is_available
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._ccb.uuid)},
         )
 
     async def async_added_to_hass(self) -> None:
-        """Register for sensor updates."""
+        """Register for sensor and availability updates."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                SIGNAL_COMFOCONNECT_AVAILABILITY.format(self._ccb.uuid),
+                self._handle_availability_update,
+            )
+        )
+
         _LOGGER.debug("Registering for fan speed")
         self.async_on_remove(
             async_dispatcher_connect(
@@ -93,6 +107,12 @@ class ComfoConnectFan(FanEntity):
         )
         await self._ccb.register_sensor(SENSORS.get(SENSOR_OPERATING_MODE))
         self._attr_preset_mode = await self._ccb.get_mode()
+
+    @callback
+    def _handle_availability_update(self, available: bool) -> None:
+        """Handle availability updates of the bridge."""
+        self._attr_available = available
+        self.async_write_ha_state()
 
     def _handle_speed_update(self, value: int) -> None:
         """Handle update callbacks."""

--- a/custom_components/comfoconnect/select.py
+++ b/custom_components/comfoconnect/select.py
@@ -26,12 +26,17 @@ from aiocomfoconnect.sensors import (
 )
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DOMAIN, SIGNAL_COMFOCONNECT_UPDATE_RECEIVED, ComfoConnectBridge
+from . import (
+    DOMAIN,
+    SIGNAL_COMFOCONNECT_AVAILABILITY,
+    SIGNAL_COMFOCONNECT_UPDATE_RECEIVED,
+    ComfoConnectBridge,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -179,12 +184,21 @@ class ComfoConnectSelect(SelectEntity):
         self.entity_description = description
         self._attr_should_poll = False if description.sensor else True
         self._attr_unique_id = f"{self._ccb.uuid}-{description.key}"
+        self._attr_available = ccb.is_available
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._ccb.uuid)},
         )
 
     async def async_added_to_hass(self) -> None:
-        """Register for sensor updates."""
+        """Register for sensor and availability updates."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                SIGNAL_COMFOCONNECT_AVAILABILITY.format(self._ccb.uuid),
+                self._handle_availability_update,
+            )
+        )
+
         if not self.entity_description.sensor:
             return
 
@@ -201,6 +215,12 @@ class ComfoConnectSelect(SelectEntity):
             )
         )
         await self._ccb.register_sensor(self.entity_description.sensor)
+
+    @callback
+    def _handle_availability_update(self, available: bool) -> None:
+        """Handle availability updates of the bridge."""
+        self._attr_available = available
+        self.async_write_ha_state()
 
     def _handle_update(self, value):
         """Handle update callbacks."""

--- a/custom_components/comfoconnect/sensor.py
+++ b/custom_components/comfoconnect/sensor.py
@@ -60,13 +60,18 @@ from homeassistant.const import (
     UnitOfTime,
     UnitOfVolumeFlowRate,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import Throttle
 
-from . import DOMAIN, SIGNAL_COMFOCONNECT_UPDATE_RECEIVED, ComfoConnectBridge
+from . import (
+    DOMAIN,
+    SIGNAL_COMFOCONNECT_AVAILABILITY,
+    SIGNAL_COMFOCONNECT_UPDATE_RECEIVED,
+    ComfoConnectBridge,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -409,12 +414,21 @@ class ComfoConnectSensor(SensorEntity):
         self._ccb = ccb
         self.entity_description = description
         self._attr_unique_id = f"{self._ccb.uuid}-{description.key}"
+        self._attr_available = ccb.is_available
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._ccb.uuid)},
         )
 
     async def async_added_to_hass(self) -> None:
-        """Register for sensor updates."""
+        """Register for sensor and availability updates."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                SIGNAL_COMFOCONNECT_AVAILABILITY.format(self._ccb.uuid),
+                self._handle_availability_update,
+            )
+        )
+
         _LOGGER.debug(
             "Registering for sensor %s (%d)",
             self.entity_description.name,
@@ -435,6 +449,12 @@ class ComfoConnectSensor(SensorEntity):
             )
         )
         await self._ccb.register_sensor(self.entity_description.ccb_sensor)
+
+    @callback
+    def _handle_availability_update(self, available: bool) -> None:
+        """Handle availability updates of the bridge."""
+        self._attr_available = available
+        self.async_write_ha_state()
 
     def _handle_update(self, value):
         """Handle update callbacks."""


### PR DESCRIPTION
This takes over #145 from @markusrauschergmxnet and @N3rdix, which needed a rebase after #161 touched the same lines in the keepalive. Both are credited as co-authors on the commit.

The entities kept showing their last value when the bridge dropped, so automations acted on stale data instead of skipping an unavailable entity. The keepalive already knows when the bridge is gone, it just did not tell anyone, there were two `# TODO: Mark sensors as available/unavailable` comments sitting there.

`ComfoConnectBridge` tracks `is_available` and fires `SIGNAL_COMFOCONNECT_AVAILABILITY` when it changes. Every entity listens for it, and starts from the availability the bridge has at that moment, so an entity added while the bridge is down does not start out looking fine.

Four things are different from #145:

* **The availability is restored right after a reconnect that works.** In #145 `set_available(False)` was called and, when the reconnect succeeded, nothing set it back, so the entities stayed unavailable until the next keepalive succeeded, up to 30 seconds later.
* **The button entities are covered too.** They stayed available while everything else went unavailable.
* **`async_write_ha_state()` instead of `schedule_update_ha_state()`.** The handler is a callback that runs in the event loop, so the async variant is the right one, and it does not add four more calls of the kind #139 wants to get rid of.
* **`async_dispatcher_send()`** for the same reason, since `set_available()` is only called from the event loop.

The listener is registered before the early return in `select.py`, so the selects that have no sensor and are polled get availability as well.

Verified locally: the tests from #163 pass, `ruff check` reports exactly the same findings as master, and `ruff format` is clean.

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)