### PR TITLE
Write the entity state from the event loop

### DIFF
--- a/custom_components/comfoconnect/binary_sensor.py
+++ b/custom_components/comfoconnect/binary_sensor.py
@@ -20,7 +20,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -125,6 +125,7 @@ class ComfoConnectBinarySensor(BinarySensorEntity):
         )
         await self._ccb.register_sensor(self.entity_description.ccb_sensor)
 
+    @callback
     def _handle_update(self, value):
         """Handle update callbacks."""
         _LOGGER.debug(
@@ -135,4 +136,4 @@ class ComfoConnectBinarySensor(BinarySensorEntity):
         )
 
         self._attr_is_on = True if value else False
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()

--- a/custom_components/comfoconnect/fan.py
+++ b/custom_components/comfoconnect/fan.py
@@ -14,7 +14,7 @@ from aiocomfoconnect.sensors import (
 )
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
@@ -94,6 +94,7 @@ class ComfoConnectFan(FanEntity):
         await self._ccb.register_sensor(SENSORS.get(SENSOR_OPERATING_MODE))
         self._attr_preset_mode = await self._ccb.get_mode()
 
+    @callback
     def _handle_speed_update(self, value: int) -> None:
         """Handle update callbacks."""
         _LOGGER.debug("Handle update for fan speed (%d): %s", SENSOR_FAN_SPEED_MODE, value)
@@ -102,8 +103,9 @@ class ComfoConnectFan(FanEntity):
         else:
             self._attr_percentage = ordered_list_item_to_percentage(FAN_SPEEDS, FAN_SPEED_MAPPING[value])
 
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()
 
+    @callback
     def _handle_mode_update(self, value: int) -> None:
         """Handle update callbacks."""
         _LOGGER.debug(
@@ -112,7 +114,7 @@ class ComfoConnectFan(FanEntity):
             value,
         )
         self._attr_preset_mode = VentilationMode.AUTO if value == -1 else VentilationMode.MANUAL
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/comfoconnect/select.py
+++ b/custom_components/comfoconnect/select.py
@@ -26,7 +26,7 @@ from aiocomfoconnect.sensors import (
 )
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -202,6 +202,7 @@ class ComfoConnectSelect(SelectEntity):
         )
         await self._ccb.register_sensor(self.entity_description.sensor)
 
+    @callback
     def _handle_update(self, value):
         """Handle update callbacks."""
         _LOGGER.debug(
@@ -212,7 +213,7 @@ class ComfoConnectSelect(SelectEntity):
         )
 
         self._attr_current_option = self.entity_description.sensor_value_fn(value)
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_update(self) -> None:
         """Update the state."""
@@ -222,4 +223,4 @@ class ComfoConnectSelect(SelectEntity):
         """Set the selected option."""
         await self.entity_description.set_value_fn(self._ccb, option)
         self._attr_current_option = option
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()

--- a/custom_components/comfoconnect/sensor.py
+++ b/custom_components/comfoconnect/sensor.py
@@ -60,7 +60,7 @@ from homeassistant.const import (
     UnitOfTime,
     UnitOfVolumeFlowRate,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -436,6 +436,7 @@ class ComfoConnectSensor(SensorEntity):
         )
         await self._ccb.register_sensor(self.entity_description.ccb_sensor)
 
+    @callback
     def _handle_update(self, value):
         """Handle update callbacks."""
         _LOGGER.debug(
@@ -449,4 +450,4 @@ class ComfoConnectSensor(SensorEntity):
             self._attr_native_value = self.entity_description.mapping(value)
         else:
             self._attr_native_value = value
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()


### PR DESCRIPTION
This takes over #140 from @jensihnow, with the part that was missing to make it safe. Credited as co-author on the commit.

Your question there was the right one. Swapping `schedule_update_ha_state()` for `async_write_ha_state()` on its own would have broken every push update, because the handlers are dispatcher targets without a `@callback` decorator. Home Assistant decides where to run them from the callable itself:

```python
def get_hassjob_callable_job_type(target):
    if asyncio.iscoroutinefunction(check_target):
        return HassJobType.Coroutinefunction
    if is_callback(check_target):          # needs @callback
        return HassJobType.Callback
    ...
    return HassJobType.Executor            # everything else
```

So they were running in a worker thread, which is exactly why they had to use `schedule_update_ha_state()`. The [thread safety page](https://developers.home-assistant.io/docs/asyncio_thread_safety/) puts it as: "When writing the state of an entity from a thread other than the event loop thread, instead use `self.schedule_update_ha_state`". The [entity page](https://developers.home-assistant.io/docs/core/entity/#subscribing-to-updates) only mentions `schedule_update_ha_state()` and never `async_write_ha_state()`, which is why the two look like they contradict each other.

Adding `@callback` fixes the premise: the handlers run in the event loop, and writing the state directly is then the correct thing to do. It also removes a pointless hop, since `dispatcher_send()` already does `loop.call_soon_threadsafe(...)` and Home Assistant was sending it straight back out to a thread, on every update, with 86 sensors registered.

Checked against the Home Assistant version we develop against, all four handlers now resolve to the loop instead of a thread:

```
sensor.ComfoConnectSensor._handle_update:            HassJobType.Callback
binary_sensor.ComfoConnectBinarySensor._handle_update: HassJobType.Callback
fan.ComfoConnectFan._handle_speed_update:            HassJobType.Callback
select.ComfoConnectSelect._handle_update:            HassJobType.Callback
```

`async_select_option()` is switched too, it is an async method so it already ran in the loop.

`ruff check` reports exactly the same findings as master and the tests pass.

Closes #140, fixes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)