### PR TITLE
Create a GitHub release when a version tag is pushed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  # Create a release when a version tag is pushed.
+  push:
+    tags:
+      - "v*"
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  release:
+    name: Create the GitHub release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out ${{ github.ref_name }} from repository ${{ github.repository }}
+        uses: actions/checkout@v4
+
+      - name: Check that the tag matches the version in the manifest
+        run: |
+          version="$(python3 -c "import json; print(json.load(open('custom_components/comfoconnect/manifest.json'))['version'])")"
+          if [ "v${version}" != "${GITHUB_REF_NAME}" ]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match version ${version} in the manifest, which is the version HACS shows."
+            exit 1
+          fi
+
+      - name: Create the release with generated release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${GITHUB_REF_NAME}" --generate-notes


### PR DESCRIPTION
Releases are made by hand at the moment. This creates the GitHub release from the tag, with the generated release notes, which is the same format the previous releases used.

No PyPI, nothing is published anywhere, HACS installs from the source at the tag. `hacs.json` has no `zip_release` and v0.4.0 has no assets, so there is nothing to attach.

There is one guard: the tag has to match the version in `manifest.json`. HACS shows that version to users, so tagging `v0.5.0` while the manifest still says `0.4.0` would leave people looking at a version that does not match the release they installed. The workflow fails before creating the release in that case. Tested against the current tree: `v0.4.0` is accepted, `v0.5.0` is rejected while the manifest says `0.4.0`.

Releasing becomes: merge the version bump, push the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)