### PR TITLE
Mark a tag with a suffix as a pre-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,4 +31,11 @@ jobs:
       - name: Create the release with generated release notes
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${GITHUB_REF_NAME}" --generate-notes
+        run: |
+          # A tag with a suffix, like v0.5.0-rc1, is a pre-release. HACS only offers those to
+          # users who turned on "Show beta versions", and it keeps them off the latest release.
+          if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
+            gh release create "${GITHUB_REF_NAME}" --generate-notes --prerelease
+          else
+            gh release create "${GITHUB_REF_NAME}" --generate-notes
+          fi


### PR DESCRIPTION
Needed before tagging a release candidate.

`gh release create` marks whatever it creates as the latest release, so tagging `v0.5.0-rc1` today would push the candidate to every HACS user as a normal update. A tag with a suffix is now created with `--prerelease`, which is exactly what the "Show beta versions" toggle in HACS keys off.

```
v0.5.0        -> latest
v0.5.0-rc1    -> pre-release
v0.5.0-beta2  -> pre-release
```

The version guard is unchanged on purpose: the tag still has to match the version in `manifest.json` exactly. That means a candidate carries the suffix there too, `"version": "0.5.0-rc1"`. HACS shows the manifest version to users, so this keeps them from seeing `0.5.0` while running a candidate, and it makes the update from the candidate to the final release an actual version change.

Releasing a candidate then looks like:

```
Release v0.5.0-rc1   (manifest and pyproject.toml both 0.5.0-rc1)  -> tag -> pre-release
Release v0.5.0       (both 0.5.0)                                  -> tag -> latest
```

`0.5.0-rc1` normalises to `0.5.0rc1` under PEP 440, so `poetry check` in CI should accept it in `pyproject.toml`. Worth confirming on the first candidate rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)