### PR TITLE
Added sensor support for the comfoclime24

### DIFF
--- a/custom_components/comfoconnect/__init__.py
+++ b/custom_components/comfoconnect/__init__.py
@@ -43,6 +43,7 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.SELECT,
     Platform.NUMBER,
+    Platform.SWITCH,
     Platform.BUTTON,
 ]
 

--- a/custom_components/comfoconnect/__init__.py
+++ b/custom_components/comfoconnect/__init__.py
@@ -17,6 +17,7 @@ from aiocomfoconnect.properties import (
     PROPERTY_FIRMWARE_VERSION,
     PROPERTY_MODEL,
     PROPERTY_NAME,
+    PROPERTY_SERIAL_NUMBER,
 )
 from aiocomfoconnect.sensors import Sensor
 from aiocomfoconnect.util import version_decode
@@ -41,6 +42,7 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
     Platform.SELECT,
+    Platform.NUMBER,
     Platform.BUTTON,
 ]
 
@@ -139,6 +141,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         via_device=(DOMAIN, bridge_info.serialNumber),
     )
 
+    # Add the ComfoClime to the device registry, if there is one on the ComfoNet bus
+    if bridge.comfoclime_node_id is not None:
+        try:
+            clime_serial = await bridge.get_property(PROPERTY_SERIAL_NUMBER, node_id=bridge.comfoclime_node_id)
+            clime_name = await bridge.get_property(PROPERTY_NAME, node_id=bridge.comfoclime_node_id)
+            clime_firmware = await bridge.get_property(PROPERTY_FIRMWARE_VERSION, node_id=bridge.comfoclime_node_id)
+        except ComfoConnectError as err:
+            _LOGGER.warning("Found a ComfoClime on the bus, but could not read its device information: %s", err)
+        else:
+            bridge.comfoclime_serial = clime_serial
+            device_registry.async_get_or_create(
+                config_entry_id=entry.entry_id,
+                identifiers={(DOMAIN, clime_serial)},
+                manufacturer="Zehnder",
+                name=clime_name,
+                model="ComfoClime",
+                sw_version=version_decode(clime_firmware),
+                via_device=(DOMAIN, bridge_info.serialNumber),
+            )
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     @callback
@@ -195,6 +217,7 @@ class ComfoConnectBridge(ComfoConnect):
         )
         self.hass = hass
         self.is_available = True
+        self.comfoclime_serial: str | None = None
 
     @callback
     def set_available(self, available: bool) -> None:

--- a/custom_components/comfoconnect/manifest.json
+++ b/custom_components/comfoconnect/manifest.json
@@ -5,7 +5,7 @@
   "dependencies": ["network"],
   "documentation": "https://www.home-assistant.io/integrations/comfoconnect",
   "integration_type": "hub",
-  "requirements": ["aiocomfoconnect==0.2.1"],
+  "requirements": ["aiocomfoconnect==0.3.0"],
   "codeowners": ["@michaelarnauts"],
   "iot_class": "local_push",
   "loggers": ["aiocomfoconnect"],

--- a/custom_components/comfoconnect/number.py
+++ b/custom_components/comfoconnect/number.py
@@ -1,0 +1,285 @@
+"""Number for the ComfoConnect integration."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from aiocomfoconnect.properties import (
+    PROPERTY_CLIME_COOLING_COMFORT_TEMP,
+    PROPERTY_CLIME_COOLING_KNEE_POINT,
+    PROPERTY_CLIME_COOLING_TEMP_LIMIT,
+    PROPERTY_CLIME_HEATING_COMFORT_TEMP,
+    PROPERTY_CLIME_HEATING_DELTA,
+    PROPERTY_CLIME_HEATING_KNEE_POINT,
+    PROPERTY_CLIME_HEATPUMP_MAX_TEMP,
+    PROPERTY_CLIME_HEATPUMP_MIN_TEMP,
+    PROPERTY_CLIME_MANUAL_TARGET_TEMP,
+    PROPERTY_RMOT_COOLING_THRESHOLD,
+    PROPERTY_RMOT_HEATING_THRESHOLD,
+    Property,
+)
+from homeassistant.components.number import NumberEntity, NumberEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import DOMAIN, SIGNAL_COMFOCONNECT_AVAILABILITY, ComfoConnectBridge
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class ComfoconnectNumberDescriptionMixin:
+    """Mixin for required keys."""
+
+    set_value_fn: Callable[[ComfoConnectBridge, float], Awaitable[Any]]
+    get_value_fn: Callable[[ComfoConnectBridge], Awaitable[Any]]
+
+
+@dataclass
+class ComfoconnectNumberEntityDescription(NumberEntityDescription, ComfoconnectNumberDescriptionMixin):
+    """Describes ComfoConnect number entity."""
+
+
+def _comfoclime_temperature_getter(prop: Property) -> Callable[[ComfoConnectBridge], Awaitable[Any]]:
+    """Build a getter for a ComfoClime temperature, which is stored in tenths of a degree."""
+
+    async def get_value(ccb: ComfoConnectBridge) -> float:
+        return await ccb.get_comfoclime_property(prop) / 10
+
+    return get_value
+
+
+def _comfoclime_temperature_setter(prop: Property) -> Callable[[ComfoConnectBridge, float], Awaitable[Any]]:
+    """Build a setter for a ComfoClime temperature, which is stored in tenths of a degree."""
+
+    async def set_value(ccb: ComfoConnectBridge, value: float) -> None:
+        await ccb.set_comfoclime_property(prop, round(value * 10))
+
+    return set_value
+
+
+def _temperature_getter(prop: Property) -> Callable[[ComfoConnectBridge], Awaitable[Any]]:
+    """Build a getter for a ventilation unit temperature, which is stored in tenths of a degree."""
+
+    async def get_value(ccb: ComfoConnectBridge) -> float:
+        return await ccb.get_property(prop) / 10
+
+    return get_value
+
+
+def _temperature_setter(prop: Property) -> Callable[[ComfoConnectBridge, float], Awaitable[Any]]:
+    """Build a setter for a ventilation unit temperature, which is stored in tenths of a degree."""
+
+    async def set_value(ccb: ComfoConnectBridge, value: float) -> None:
+        await ccb.set_property_typed(prop.unit, prop.subunit, prop.property_id, round(value * 10), prop.property_type)
+
+    return set_value
+
+
+COMFOCLIME_NUMBER_TYPES = (
+    ComfoconnectNumberEntityDescription(
+        key="comfoclime_heating_comfort_temperature",
+        name="Heating comfort temperature",
+        entity_category=EntityCategory.CONFIG,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        native_min_value=15,
+        native_max_value=25,
+        native_step=0.5,
+        get_value_fn=_comfoclime_temperature_getter(PROPERTY_CLIME_HEATING_COMFORT_TEMP),
+        set_value_fn=_comfoclime_temperature_setter(PROPERTY_CLIME_HEATING_COMFORT_TEMP),
+    ),
+    ComfoconnectNumberEntityDescription(
+        key="comfoclime_cooling_comfort_temperature",
+        name="Cooling comfort temperature",
+        entity_category=EntityCategory.CONFIG,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        native_min_value=20,
+        native_max_value=28,
+        native_step=0.5,
+        get_value_fn=_comfoclime_temperature_getter(PROPERTY_CLIME_COOLING_COMFORT_TEMP),
+        set_value_fn=_comfoclime_temperature_setter(PROPERTY_CLIME_COOLING_COMFORT_TEMP),
+    ),
+    ComfoconnectNumberEntityDescription(
+        key="comfoclime_manual_target_temperature",
+        name="Manual target temperature",
+        entity_category=EntityCategory.CONFIG,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        native_min_value=18,
+        native_max_value=28,
+        native_step=0.5,
+        get_value_fn=_comfoclime_temperature_getter(PROPERTY_CLIME_MANUAL_TARGET_TEMP),
+        set_value_fn=_comfoclime_temperature_setter(PROPERTY_CLIME_MANUAL_TARGET_TEMP),
+    ),
+    ComfoconnectNumberEntityDescription(
+        key="comfoclime_heating_knee_point",
+        name="Heating knee point",
+        entity_category=EntityCategory.CONFIG,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        native_min_value=5,
+        native_max_value=15,
+        native_step=0.5,
+        entity_registry_enabled_default=False,
+        get_value_fn=_comfoclime_temperature_getter(PROPERTY_CLIME_HEATING_KNEE_POINT),
+        set_value_fn=_comfoclime_temperature_setter(PROPERTY_CLIME_HEATING_KNEE_POINT),
+    ),
+    ComfoconnectNumberEntityDescription(
+        key="comfoclime_cooling_knee_point",
+        name="Cooling knee point",
+        entity_category=EntityCategory.CONFIG,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        native_min_value=15,
+        native_max_value=25,
+        native_step=0.5,
+        entity_registry_enabled_default=False,
+        get_value_fn=_comfoclime_temperature_getter(PROPERTY_CLIME_COOLING_KNEE_POINT),
+        set_value_fn=_comfoclime_temperature_setter(PROPERTY_CLIME_COOLING_KNEE_POINT),
+    ),
+    ComfoconnectNumberEntityDescription(
+        key="comfoclime_cooling_temperature_limit",
+        name="Cooling temperature limit",
+        entity_category=EntityCategory.CONFIG,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        native_min_value=20,
+        native_max_value=28,
+        native_step=0.5,
+        entity_registry_enabled_default=False,
+        get_value_fn=_comfoclime_temperature_getter(PROPERTY_CLIME_COOLING_TEMP_LIMIT),
+        set_value_fn=_comfoclime_temperature_setter(PROPERTY_CLIME_COOLING_TEMP_LIMIT),
+    ),
+    ComfoconnectNumberEntityDescription(
+        key="comfoclime_heating_reduction_delta",
+        name="Heating reduction delta",
+        entity_category=EntityCategory.CONFIG,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        native_min_value=0,
+        native_max_value=5,
+        native_step=0.5,
+        entity_registry_enabled_default=False,
+        get_value_fn=_comfoclime_temperature_getter(PROPERTY_CLIME_HEATING_DELTA),
+        set_value_fn=_comfoclime_temperature_setter(PROPERTY_CLIME_HEATING_DELTA),
+    ),
+    ComfoconnectNumberEntityDescription(
+        key="comfoclime_heatpump_min_temperature",
+        name="Heat pump minimum temperature",
+        entity_category=EntityCategory.CONFIG,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        native_min_value=10,
+        native_max_value=17,
+        native_step=1,
+        entity_registry_enabled_default=False,
+        get_value_fn=_comfoclime_temperature_getter(PROPERTY_CLIME_HEATPUMP_MIN_TEMP),
+        set_value_fn=_comfoclime_temperature_setter(PROPERTY_CLIME_HEATPUMP_MIN_TEMP),
+    ),
+    ComfoconnectNumberEntityDescription(
+        key="comfoclime_heatpump_max_temperature",
+        name="Heat pump maximum temperature",
+        entity_category=EntityCategory.CONFIG,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        native_min_value=40,
+        native_max_value=60,
+        native_step=1,
+        entity_registry_enabled_default=False,
+        get_value_fn=_comfoclime_temperature_getter(PROPERTY_CLIME_HEATPUMP_MAX_TEMP),
+        set_value_fn=_comfoclime_temperature_setter(PROPERTY_CLIME_HEATPUMP_MAX_TEMP),
+    ),
+)
+
+# These live on the ventilation unit, but are only meaningful when a ComfoClime drives the seasons.
+COMFOCLIME_UNIT_NUMBER_TYPES = (
+    ComfoconnectNumberEntityDescription(
+        key="rmot_heating_threshold",
+        name="RMOT heating threshold",
+        entity_category=EntityCategory.CONFIG,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        native_min_value=5,
+        native_max_value=20,
+        native_step=0.5,
+        entity_registry_enabled_default=False,
+        get_value_fn=_temperature_getter(PROPERTY_RMOT_HEATING_THRESHOLD),
+        set_value_fn=_temperature_setter(PROPERTY_RMOT_HEATING_THRESHOLD),
+    ),
+    ComfoconnectNumberEntityDescription(
+        key="rmot_cooling_threshold",
+        name="RMOT cooling threshold",
+        entity_category=EntityCategory.CONFIG,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        native_min_value=5,
+        native_max_value=35,
+        native_step=0.5,
+        entity_registry_enabled_default=False,
+        get_value_fn=_temperature_getter(PROPERTY_RMOT_COOLING_THRESHOLD),
+        set_value_fn=_temperature_setter(PROPERTY_RMOT_COOLING_THRESHOLD),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the ComfoConnect numbers."""
+    ccb = hass.data[DOMAIN][config_entry.entry_id]
+
+    if not ccb.comfoclime_serial:
+        return
+
+    numbers = [ComfoConnectNumber(ccb=ccb, description=description, device_id=ccb.comfoclime_serial) for description in COMFOCLIME_NUMBER_TYPES]
+    numbers += [ComfoConnectNumber(ccb=ccb, description=description) for description in COMFOCLIME_UNIT_NUMBER_TYPES]
+
+    async_add_entities(numbers, True)
+
+
+class ComfoConnectNumber(NumberEntity):
+    """Representation of a ComfoConnect number."""
+
+    _attr_has_entity_name = True
+    entity_description: ComfoconnectNumberEntityDescription
+
+    def __init__(
+        self,
+        ccb: ComfoConnectBridge,
+        description: ComfoconnectNumberEntityDescription,
+        device_id: str | None = None,
+    ) -> None:
+        """Initialize the ComfoConnect number."""
+        self._ccb = ccb
+        self.entity_description = description
+        self._attr_unique_id = f"{self._ccb.uuid}-{description.key}"
+        self._attr_available = ccb.is_available
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device_id or self._ccb.uuid)},
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Register for availability changes."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                SIGNAL_COMFOCONNECT_AVAILABILITY.format(self._ccb.uuid),
+                self._handle_availability_update,
+            )
+        )
+
+    @callback
+    def _handle_availability_update(self, available: bool) -> None:
+        """Handle bridge availability changes."""
+        self._attr_available = available
+        self.async_write_ha_state()
+
+    async def async_update(self) -> None:
+        """Update the state."""
+        self._attr_native_value = await self.entity_description.get_value_fn(self._ccb)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the value."""
+        await self.entity_description.set_value_fn(self._ccb, value)
+        self._attr_native_value = value
+        self.async_write_ha_state()

--- a/custom_components/comfoconnect/select.py
+++ b/custom_components/comfoconnect/select.py
@@ -8,11 +8,19 @@ from dataclasses import dataclass
 from typing import Any, Callable, cast
 
 from aiocomfoconnect.const import (
+    COMFOCLIME_SEASONS,
+    COMFOCLIME_TEMPERATURE_PROFILES,
     ComfoCoolMode,
     VentilationBalance,
     VentilationMode,
     VentilationSetting,
     VentilationTemperatureProfile,
+)
+from aiocomfoconnect.properties import (
+    PROPERTY_CLIME_AUTO_SEASON,
+    PROPERTY_CLIME_SEASON,
+    PROPERTY_CLIME_TEMPERATURE_PROFILE,
+    Property,
 )
 from aiocomfoconnect.sensors import (
     SENSOR_BYPASS_ACTIVATION_STATE,
@@ -154,6 +162,55 @@ SELECT_TYPES = (
 )
 
 
+def _comfoclime_option_getter(prop: Property, options: dict[int, str]) -> Callable[[ComfoConnectBridge], Awaitable[Any]]:
+    """Build a getter that maps a raw ComfoClime property value to an option."""
+
+    async def get_value(ccb: ComfoConnectBridge) -> str | None:
+        return options.get(await ccb.get_comfoclime_property(prop))
+
+    return get_value
+
+
+def _comfoclime_option_setter(prop: Property, options: dict[int, str]) -> Callable[[ComfoConnectBridge, str], Awaitable[Any]]:
+    """Build a setter that maps an option back to a raw ComfoClime property value."""
+    values = {option: value for value, option in options.items()}
+
+    async def set_value(ccb: ComfoConnectBridge, option: str) -> None:
+        await ccb.set_comfoclime_property(prop, values[option])
+
+    return set_value
+
+
+COMFOCLIME_ON_OFF = {0: VentilationSetting.OFF, 1: VentilationSetting.ON}
+
+COMFOCLIME_SELECT_TYPES = (
+    ComfoconnectSelectEntityDescription(
+        key="comfoclime_season",
+        name="Season",
+        entity_category=EntityCategory.CONFIG,
+        get_value_fn=_comfoclime_option_getter(PROPERTY_CLIME_SEASON, COMFOCLIME_SEASONS),
+        set_value_fn=_comfoclime_option_setter(PROPERTY_CLIME_SEASON, COMFOCLIME_SEASONS),
+        options=list(COMFOCLIME_SEASONS.values()),
+    ),
+    ComfoconnectSelectEntityDescription(
+        key="comfoclime_temperature_profile",
+        name="Temperature profile",
+        entity_category=EntityCategory.CONFIG,
+        get_value_fn=_comfoclime_option_getter(PROPERTY_CLIME_TEMPERATURE_PROFILE, COMFOCLIME_TEMPERATURE_PROFILES),
+        set_value_fn=_comfoclime_option_setter(PROPERTY_CLIME_TEMPERATURE_PROFILE, COMFOCLIME_TEMPERATURE_PROFILES),
+        options=list(COMFOCLIME_TEMPERATURE_PROFILES.values()),
+    ),
+    ComfoconnectSelectEntityDescription(
+        key="comfoclime_automatic_season",
+        name="Automatic season detection",
+        entity_category=EntityCategory.CONFIG,
+        get_value_fn=_comfoclime_option_getter(PROPERTY_CLIME_AUTO_SEASON, COMFOCLIME_ON_OFF),
+        set_value_fn=_comfoclime_option_setter(PROPERTY_CLIME_AUTO_SEASON, COMFOCLIME_ON_OFF),
+        options=list(COMFOCLIME_ON_OFF.values()),
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -163,6 +220,12 @@ async def async_setup_entry(
     ccb = hass.data[DOMAIN][config_entry.entry_id]
 
     selects = [ComfoConnectSelect(ccb=ccb, config_entry=config_entry, description=description) for description in SELECT_TYPES]
+
+    if ccb.comfoclime_serial:
+        selects += [
+            ComfoConnectSelect(ccb=ccb, config_entry=config_entry, description=description, device_id=ccb.comfoclime_serial)
+            for description in COMFOCLIME_SELECT_TYPES
+        ]
 
     async_add_entities(selects, True)
 
@@ -178,6 +241,7 @@ class ComfoConnectSelect(SelectEntity):
         ccb: ComfoConnectBridge,
         config_entry: ConfigEntry,
         description: ComfoconnectSelectEntityDescription,
+        device_id: str | None = None,
     ) -> None:
         """Initialize the ComfoConnect select."""
         self._ccb = ccb
@@ -186,7 +250,7 @@ class ComfoConnectSelect(SelectEntity):
         self._attr_unique_id = f"{self._ccb.uuid}-{description.key}"
         self._attr_available = ccb.is_available
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._ccb.uuid)},
+            identifiers={(DOMAIN, device_id or self._ccb.uuid)},
         )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/comfoconnect/sensor.py
+++ b/custom_components/comfoconnect/sensor.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Callable
 
+from aiocomfoconnect.const import COMFOCLIME_DEVICE_MODES
 from aiocomfoconnect.sensors import (
     SENSOR_AIRFLOW_CONSTRAINTS,
     SENSOR_ANALOG_INPUT_1,
@@ -14,6 +15,18 @@ from aiocomfoconnect.sensors import (
     SENSOR_ANALOG_INPUT_3,
     SENSOR_ANALOG_INPUT_4,
     SENSOR_BYPASS_STATE,
+    SENSOR_COMFOCLIME_COMFORT_TEMPERATURE,
+    SENSOR_COMFOCLIME_DEVICE_MODE,
+    SENSOR_COMFOCLIME_HEATPUMP_DUTY,
+    SENSOR_COMFOCLIME_INDOOR_TEMPERATURE,
+    SENSOR_COMFOCLIME_POWER_USAGE,
+    SENSOR_COMFOCLIME_TARGET_TEMPERATURE,
+    SENSOR_COMFOCLIME_TEMPERATURE_COMPRESSOR,
+    SENSOR_COMFOCLIME_TEMPERATURE_EXHAUST,
+    SENSOR_COMFOCLIME_TEMPERATURE_EXHAUST_COIL,
+    SENSOR_COMFOCLIME_TEMPERATURE_SUPPLY,
+    SENSOR_COMFOCLIME_TEMPERATURE_SUPPLY_COIL,
+    SENSOR_COMFOCLIME_TPMA_TEMPERATURE,
     SENSOR_COMFOCOOL_CONDENSOR_TEMP,
     SENSOR_COMFOFOND_GHE_STATE,
     SENSOR_COMFOFOND_TEMP_GROUND,
@@ -383,6 +396,116 @@ SENSOR_TYPES = (
     ),
 )
 
+COMFOCLIME_SENSOR_TYPES = (
+    ComfoconnectSensorEntityDescription(
+        key=SENSOR_COMFOCLIME_INDOOR_TEMPERATURE,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        name="Indoor temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        ccb_sensor=SENSORS.get(SENSOR_COMFOCLIME_INDOOR_TEMPERATURE),
+    ),
+    ComfoconnectSensorEntityDescription(
+        key=SENSOR_COMFOCLIME_TARGET_TEMPERATURE,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        name="Target temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        ccb_sensor=SENSORS.get(SENSOR_COMFOCLIME_TARGET_TEMPERATURE),
+    ),
+    ComfoconnectSensorEntityDescription(
+        key=SENSOR_COMFOCLIME_COMFORT_TEMPERATURE,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        name="Comfort temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        ccb_sensor=SENSORS.get(SENSOR_COMFOCLIME_COMFORT_TEMPERATURE),
+    ),
+    ComfoconnectSensorEntityDescription(
+        key=SENSOR_COMFOCLIME_DEVICE_MODE,
+        device_class=SensorDeviceClass.ENUM,
+        name="Device mode",
+        options=list(COMFOCLIME_DEVICE_MODES.values()),
+        ccb_sensor=SENSORS.get(SENSOR_COMFOCLIME_DEVICE_MODE),
+        mapping=COMFOCLIME_DEVICE_MODES.get,
+    ),
+    ComfoconnectSensorEntityDescription(
+        key=SENSOR_COMFOCLIME_POWER_USAGE,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        name="Power usage",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        ccb_sensor=SENSORS.get(SENSOR_COMFOCLIME_POWER_USAGE),
+        throttle=True,
+    ),
+    ComfoconnectSensorEntityDescription(
+        key=SENSOR_COMFOCLIME_HEATPUMP_DUTY,
+        state_class=SensorStateClass.MEASUREMENT,
+        name="Heat pump duty",
+        native_unit_of_measurement=PERCENTAGE,
+        ccb_sensor=SENSORS.get(SENSOR_COMFOCLIME_HEATPUMP_DUTY),
+        throttle=True,
+    ),
+    ComfoconnectSensorEntityDescription(
+        key=SENSOR_COMFOCLIME_TEMPERATURE_SUPPLY,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        name="Supply air temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        ccb_sensor=SENSORS.get(SENSOR_COMFOCLIME_TEMPERATURE_SUPPLY),
+    ),
+    ComfoconnectSensorEntityDescription(
+        key=SENSOR_COMFOCLIME_TEMPERATURE_EXHAUST,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        name="Exhaust air temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        ccb_sensor=SENSORS.get(SENSOR_COMFOCLIME_TEMPERATURE_EXHAUST),
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    ComfoconnectSensorEntityDescription(
+        key=SENSOR_COMFOCLIME_TPMA_TEMPERATURE,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        name="TPMA temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        ccb_sensor=SENSORS.get(SENSOR_COMFOCLIME_TPMA_TEMPERATURE),
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    ComfoconnectSensorEntityDescription(
+        key=SENSOR_COMFOCLIME_TEMPERATURE_SUPPLY_COIL,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        name="Supply coil temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        ccb_sensor=SENSORS.get(SENSOR_COMFOCLIME_TEMPERATURE_SUPPLY_COIL),
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    ComfoconnectSensorEntityDescription(
+        key=SENSOR_COMFOCLIME_TEMPERATURE_EXHAUST_COIL,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        name="Exhaust coil temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        ccb_sensor=SENSORS.get(SENSOR_COMFOCLIME_TEMPERATURE_EXHAUST_COIL),
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    ComfoconnectSensorEntityDescription(
+        key=SENSOR_COMFOCLIME_TEMPERATURE_COMPRESSOR,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        name="Compressor temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        ccb_sensor=SENSORS.get(SENSOR_COMFOCLIME_TEMPERATURE_COMPRESSOR),
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -393,6 +516,12 @@ async def async_setup_entry(
     ccb = hass.data[DOMAIN][config_entry.entry_id]
 
     sensors = [ComfoConnectSensor(ccb=ccb, config_entry=config_entry, description=description) for description in SENSOR_TYPES]
+
+    if ccb.comfoclime_serial:
+        sensors += [
+            ComfoConnectSensor(ccb=ccb, config_entry=config_entry, description=description, device_id=ccb.comfoclime_serial)
+            for description in COMFOCLIME_SENSOR_TYPES
+        ]
 
     async_add_entities(sensors, True)
 
@@ -409,6 +538,7 @@ class ComfoConnectSensor(SensorEntity):
         ccb: ComfoConnectBridge,
         config_entry: ConfigEntry,
         description: ComfoconnectSensorEntityDescription,
+        device_id: str | None = None,
     ) -> None:
         """Initialize the ComfoConnect sensor."""
         self._ccb = ccb
@@ -416,7 +546,7 @@ class ComfoConnectSensor(SensorEntity):
         self._attr_unique_id = f"{self._ccb.uuid}-{description.key}"
         self._attr_available = ccb.is_available
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._ccb.uuid)},
+            identifiers={(DOMAIN, device_id or self._ccb.uuid)},
         )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/comfoconnect/switch.py
+++ b/custom_components/comfoconnect/switch.py
@@ -1,0 +1,123 @@
+"""Switch entities for the ComfoConnect integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+from aiocomfoconnect.properties import PROPERTY_CLIME_HEATPUMP_STANDBY
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import DOMAIN, SIGNAL_COMFOCONNECT_AVAILABILITY, ComfoConnectBridge
+
+
+@dataclass
+class ComfoconnectSwitchDescriptionMixin:
+    """Mixin for switch property accessors."""
+
+    set_value_fn: Callable[[ComfoConnectBridge, bool], Awaitable[Any]]
+    get_value_fn: Callable[[ComfoConnectBridge], Awaitable[bool]]
+
+
+@dataclass
+class ComfoconnectSwitchEntityDescription(SwitchEntityDescription, ComfoconnectSwitchDescriptionMixin):
+    """Describe a ComfoConnect switch."""
+
+
+async def _get_heatpump_on(ccb: ComfoConnectBridge) -> bool:
+    """Return true when the ComfoClime heat pump is not in standby."""
+    standby = await ccb.get_comfoclime_property(PROPERTY_CLIME_HEATPUMP_STANDBY)
+    return not bool(standby)
+
+
+async def _set_heatpump_on(ccb: ComfoConnectBridge, is_on: bool) -> None:
+    """Set the ComfoClime standby property from the switch state."""
+    await ccb.set_comfoclime_property(PROPERTY_CLIME_HEATPUMP_STANDBY, int(not is_on))
+
+
+SWITCH_TYPES = (
+    ComfoconnectSwitchEntityDescription(
+        key="comfoclime_heatpump",
+        name="Heat pump",
+        icon="mdi:heat-pump",
+        entity_category=EntityCategory.CONFIG,
+        get_value_fn=_get_heatpump_on,
+        set_value_fn=_set_heatpump_on,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up ComfoConnect switches."""
+    ccb = hass.data[DOMAIN][config_entry.entry_id]
+    if not ccb.comfoclime_serial:
+        return
+
+    async_add_entities(
+        [
+            ComfoConnectSwitch(ccb, description, ccb.comfoclime_serial)
+            for description in SWITCH_TYPES
+        ],
+        True,
+    )
+
+
+class ComfoConnectSwitch(SwitchEntity):
+    """Representation of a ComfoClime switch."""
+
+    _attr_has_entity_name = True
+    entity_description: ComfoconnectSwitchEntityDescription
+
+    def __init__(
+        self,
+        ccb: ComfoConnectBridge,
+        description: ComfoconnectSwitchEntityDescription,
+        device_id: str,
+    ) -> None:
+        """Initialize the switch."""
+        self._ccb = ccb
+        self.entity_description = description
+        self._attr_unique_id = f"{ccb.uuid}-{description.key}"
+        self._attr_available = ccb.is_available
+        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, device_id)})
+
+    async def async_added_to_hass(self) -> None:
+        """Register for bridge availability changes."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                SIGNAL_COMFOCONNECT_AVAILABILITY.format(self._ccb.uuid),
+                self._handle_availability_update,
+            )
+        )
+
+    @callback
+    def _handle_availability_update(self, available: bool) -> None:
+        """Handle bridge availability changes."""
+        self._attr_available = available
+        self.async_write_ha_state()
+
+    async def async_update(self) -> None:
+        """Read the current standby state."""
+        self._attr_is_on = await self.entity_description.get_value_fn(self._ccb)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Take the heat pump out of standby."""
+        await self.entity_description.set_value_fn(self._ccb, True)
+        await self.async_update()
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Put the heat pump in standby."""
+        await self.entity_description.set_value_fn(self._ccb, False)
+        await self.async_update()
+        self.async_write_ha_state()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{include = "custom_components/comfoconnect"}]
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.13"
-aiocomfoconnect = "0.2.1"
+aiocomfoconnect = "0.3.0"
 
 [tool.poetry.group.dev.dependencies]
 homeassistant = "^2024.11.0b1"


### PR DESCRIPTION
This PR add support for the comfoclime24 detection, monitoring and control in homeassistant. 

This requires aiocomfoconnect [PR#85](/michaelarnauts/aiocomfoconnect/pull/85/changes]) to be able to fetch the data. 

This is based on the work from [msfuture/comfoclime](/msfuture/comfoclime)